### PR TITLE
Added option to disable fold saving

### DIFF
--- a/doc/taskwiki.txt
+++ b/doc/taskwiki.txt
@@ -663,6 +663,10 @@ constructs.
     use the same colors for task highlighting as those defined in
     taskwarrior.
 
+*taskwiki_dont_preserve_folds*
+    If set to a non-empty value (such as "yes"), taskwiki will not
+    preserve folding when entering or leaving a vimwiki buffer.
+
 *taskwiki_disable*
     Setting any non-empty value for this variable will disable taskwiki.
 

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -30,9 +30,11 @@ augroup taskwiki
     autocmd!
     " Update to TW upon saving
     execute "autocmd BufWrite *.".expand('%:e')." TaskWikiBufferSave"
-    " Save and load the view to preserve folding
-    execute "autocmd BufWinLeave *.".expand('%:e')." mkview"
-    execute "autocmd BufWinEnter *.".expand('%:e')." silent loadview"
+    " Save and load the view to preserve folding, if desired
+    if !exists('g:taskwiki_dont_preserve_folds')
+      execute "autocmd BufWinLeave *.".expand('%:e')." mkview"
+      execute "autocmd BufWinEnter *.".expand('%:e')." silent loadview"
+    endif
 augroup END
 
 " Global update commands


### PR DESCRIPTION
Since the save/restore feature always seemed to close all folds on entering a vimwiki buffer and I also didn't like the way it was cluttering my .vim/view folder, I decided to make this feature optional. I would appreciate it, if you could add this option to the main fork.