### PR TITLE
Fix access to vim.buffers list when it is sparse, e.g. in neovim

### DIFF
--- a/taskwiki/cache.py
+++ b/taskwiki/cache.py
@@ -5,20 +5,19 @@ import vwtask
 import viewport
 import regexp
 import store
-
-NEOVIM = (vim.eval('has("nvim")') == "1")
+import util
 
 class BufferProxy(object):
 
     def __init__(self, number):
         self.data = []
-        self.buffer_number = number - 1 if NEOVIM else number
+        self.buffer_number = number
 
     def obtain(self):
-        self.data = vim.buffers[self.buffer_number][:]
+        self.data = util.get_buffer(self.buffer_number)[:]
 
     def push(self):
-        vim.buffers[self.buffer_number][:] = self.data
+        util.get_buffer(self.buffer_number)[:] = self.data
 
     def __getitem__(self, index):
         try:

--- a/taskwiki/util.py
+++ b/taskwiki/util.py
@@ -114,6 +114,17 @@ def get_current_window():
     except AttributeError:
         return int(vim.eval('winnr()')) - 1
 
+def get_buffer(number):
+    """
+    Returns a buffer with specfied number. Provides a workaround for Neovim.
+
+    Note that vim.buffers may not contain all buffers with sequential numbers.
+    """
+
+    buffers = [buffer for buffer in vim.buffers if buffer.number == number]
+    assert len(buffers) == 1
+    return buffers[0]
+
 def convert_colorstring_for_vim(string):
     BASIC_COLORS = [
         "blue", "yellow", "green", "red",


### PR DESCRIPTION
This PR should resolve issue #96.
As far as I can tell, there is no need to handle vim/neovim cases separately, because following patch works on both for me.