### PR TITLE
Add option to disable concealcursor changes

### DIFF
--- a/after/syntax/vimwiki.vim
+++ b/after/syntax/vimwiki.vim
@@ -42,8 +42,10 @@ syntax match TaskWikiTaskWaiting containedin=TaskWikiTask contained /\s*\*\s\[W\
 syntax match TaskWikiTaskPriority containedin=TaskWikiTask contained /\( !\| !!\| !!!\)\( \)\@=/
 
 " Set concealed parts as really concealed in normal mode, and with cursor over
-setlocal conceallevel=3
-setlocal concealcursor=nc
+if !exists('g:taskwiki_disable_concealcursor')
+  setlocal conceallevel=3
+  setlocal concealcursor=nc
+endif
 
 " Configure custom FoldText function
 " Altered version of the VimwikiFoldText

--- a/after/syntax/vimwiki.vim
+++ b/after/syntax/vimwiki.vim
@@ -42,8 +42,9 @@ syntax match TaskWikiTaskWaiting containedin=TaskWikiTask contained /\s*\*\s\[W\
 syntax match TaskWikiTaskPriority containedin=TaskWikiTask contained /\( !\| !!\| !!!\)\( \)\@=/
 
 " Set concealed parts as really concealed in normal mode, and with cursor over
+" (unless disabled by user)
+setlocal conceallevel=3
 if !exists('g:taskwiki_disable_concealcursor')
-  setlocal conceallevel=3
   setlocal concealcursor=nc
 endif
 

--- a/doc/taskwiki.txt
+++ b/doc/taskwiki.txt
@@ -667,6 +667,10 @@ constructs.
     If set to a non-empty value (such as "yes"), taskwiki will not
     preserve folding when entering or leaving a vimwiki buffer.
 
+*taskwiki_disable_concealcursor*
+    If set to any non-empty value (such as "yes"), taskwiki will not conceal
+    characters on the cursor line in normal mode via `concealcursor=nc`.
+
 *taskwiki_disable*
     Setting any non-empty value for this variable will disable taskwiki.
 


### PR DESCRIPTION
Setting option `taskwiki_disable_concealcursor` prevents taskwiki settings `concealcursor` and `conceallevel` to preserve link highlighting behaviour of vimwiki in normal mode. Addresses #106