### PR TITLE
VimwikiTask: dont remove recur from recur instance

### DIFF
--- a/taskwiki/vwtask.py
+++ b/taskwiki/vwtask.py
@@ -121,7 +121,6 @@ class VimwikiTask(object):
                 self.task['start'] = None
                 self.task['end'] = None
                 self.task['wait'] = None
-                self.task['recur'] = None
 
             # To get local time aware timestamp, we need to convert to
             # from local datetime to UTC time, since that is what
@@ -268,7 +267,7 @@ class VimwikiTask(object):
                 self.cache.task[self.uuid] = self.__unsaved_task
                 self.__unsaved_task = None
 
-            # If we saved the task, we need to update. Hooks may have chaned data.
+            # If we saved the task, we need to update. Hooks may have changed data.
             self.update_from_task()
 
     def get_completed_mark(self):


### PR DESCRIPTION
If a task is an instance of a recurring task prototype, it will
currently not be marked as recurring with [R]. Thus its completed_mark
can be ' '. In that case taskwiki tried to set 'recur' to None, which is
equivalent to `task 42 modify recur:` and causes an error:
> You cannot remove the recurrence from a recurring task.

Setting the status of a parent recurring task to 'pending' will be
ignored as well, so the removed line was useless.