### PR TITLE
Test: coverage for #122

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -61,7 +61,7 @@ class IntegrationTest(object):
         except RuntimeError:
             if retry > 0:
                 sleep(2)
-                self.start_client(client, retry=retry-1)
+                self.start_client(retry=retry-1)
             else:
                 raise
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -148,11 +148,12 @@ class IntegrationTest(object):
             elif not any([scriptfile in line for line in scriptnames]):
                 return False
 
-        # Assert only note about Bram being maintainer is in messages
+        # Assert only note about Bram or Mike being maintainer is in messages
         bramline = u'Messages maintainer: Bram Moolenaar <Bram@vim.org>'
+        mikeline = u'Messages maintainer: Mike Williams <mrw@eandem.co.uk>'
         if not soft:
-            assert self.client.command('messages') == bramline
-        elif not self.client.command('messages') == bramline:
+            assert self.client.command('messages') in (bramline, mikeline)
+        elif self.client.command('messages') not in (bramline, mikeline):
             return False
 
         # Assert that TW and cache objects exist

--- a/tests/test_vwtask.py
+++ b/tests/test_vwtask.py
@@ -456,6 +456,29 @@ class TestChildTaskCreation(IntegrationTest):
         assert parent['depends'] == set([child])
 
 
+class TestChildTaskCreationLimit(IntegrationTest):
+
+    viminput = """
+    * [ ] This is not a parent task
+    * This is the parent entry
+      * [ ] This is not a child task
+    """
+
+    vimoutput = """
+    * [ ] This is not a parent task  #{uuid}
+    * This is the parent entry
+      * [ ] This is not a child task  #{uuid}
+    """
+
+    def execute(self):
+        self.command("w", regex="written$", lines=1)
+
+        parent = self.tw.tasks.filter(description="This is not a parent task")[0]
+        child = self.tw.tasks.filter(description="This is not a child task")[0]
+
+        assert parent['depends'] == set()
+
+
 class TestChildTaskModification(IntegrationTest):
 
     viminput = """


### PR DESCRIPTION
I got all tests to run, by adding the en_GB locale and using `python2 -m pytest`. So then I could add the missing coverage test from pull request #122. In fact apart from the sanity test there where a lot of tests that depended on the exact wording of vim (error) messages, though en_US and en_GB do not differ there. I hope this ok.

Adding a whole integration test seemed like a bit too much, but was the easiest thing for me to do.