### PR TITLE
VimwikiTask: Omit 00:00 time from due date

### DIFF
--- a/taskwiki/vwtask.py
+++ b/taskwiki/vwtask.py
@@ -316,6 +316,11 @@ class VimwikiTask(object):
             self._buffer_data = buffer_data
 
     def __str__(self):
+        due_str = ' ' + (
+                self['due'].strftime(regexp.DATETIME_FORMAT) if self['due'].time() else
+                self['due'].strftime(regexp.DATE_FORMAT)
+                ) if self['due'] else ''
+
         return ''.join([
             self['indent'],
             '* [',
@@ -324,7 +329,7 @@ class VimwikiTask(object):
             (self['description'].encode('utf-8') if six.PY2 else self['description'])
                 if self['description'] else 'TEXT MISSING?',
             ' ' + '!' * self.priority_from_tw_format if self['priority'] else '',
-            ' ' + self['due'].strftime(regexp.DATETIME_FORMAT) if self['due'] else '',
+            due_str,
             '  #' + self.uuid.vim_representation(self.cache) if self.uuid else '',
         ])
 

--- a/tests/test_viewport.py
+++ b/tests/test_viewport.py
@@ -386,13 +386,13 @@ class TestViewportsSortedGeneration(IntegrationTest):
 
     vimoutput = """
     === Work tasks | +work ===
-    * [ ] main task 1 (2015-08-07 00:00)  #{uuid}
-        * [ ] sub task 1a (2015-08-01 00:00)  #{uuid}
+    * [ ] main task 1 (2015-08-07)  #{uuid}
+        * [ ] sub task 1a (2015-08-01)  #{uuid}
             * [ ] sub task 1aa  #{uuid}
         * [ ] sub task 1b  #{uuid}
-    * [ ] main task 2 (2015-08-08 00:00)  #{uuid}
-    * [ ] main task 3 (2015-08-09 00:00)  #{uuid}
-        * [ ] sub task 3a (2015-08-03 00:00)  #{uuid}
+    * [ ] main task 2 (2015-08-08)  #{uuid}
+    * [ ] main task 3 (2015-08-09)  #{uuid}
+        * [ ] sub task 3a (2015-08-03)  #{uuid}
         * [ ] sub task 3b  #{uuid}
     * [ ] main task 4  #{uuid}
     """
@@ -427,12 +427,12 @@ class TestViewportsSortedGenerationReverse(TestViewportsSortedGeneration):
 
     vimoutput = """
     === Work tasks | +work ===
-    * [ ] main task 3 (2015-08-09 00:00)  #{uuid}
-        * [ ] sub task 3a (2015-08-03 00:00)  #{uuid}
+    * [ ] main task 3 (2015-08-09)  #{uuid}
+        * [ ] sub task 3a (2015-08-03)  #{uuid}
         * [ ] sub task 3b  #{uuid}
-    * [ ] main task 2 (2015-08-08 00:00)  #{uuid}
-    * [ ] main task 1 (2015-08-07 00:00)  #{uuid}
-        * [ ] sub task 1a (2015-08-01 00:00)  #{uuid}
+    * [ ] main task 2 (2015-08-08)  #{uuid}
+    * [ ] main task 1 (2015-08-07)  #{uuid}
+        * [ ] sub task 1a (2015-08-01)  #{uuid}
             * [ ] sub task 1aa  #{uuid}
         * [ ] sub task 1b  #{uuid}
     * [ ] main task 4  #{uuid}
@@ -454,12 +454,12 @@ class TestViewportsMultilevelSortedGeneration(IntegrationTest):
 
     vimoutput = """
     === Work tasks | project:Work or project:Home ===
-    * [ ] home task 1 (2015-08-01 00:00)  #{uuid}
-    * [ ] home task 2 (2015-08-02 00:00)  #{uuid}
-    * [ ] home task 3 (2015-08-03 00:00)  #{uuid}
-    * [ ] work task 1 (2015-08-01 00:00)  #{uuid}
-    * [ ] work task 2 (2015-08-02 00:00)  #{uuid}
-    * [ ] work task 3 (2015-08-03 00:00)  #{uuid}
+    * [ ] home task 1 (2015-08-01)  #{uuid}
+    * [ ] home task 2 (2015-08-02)  #{uuid}
+    * [ ] home task 3 (2015-08-03)  #{uuid}
+    * [ ] work task 1 (2015-08-01)  #{uuid}
+    * [ ] work task 2 (2015-08-02)  #{uuid}
+    * [ ] work task 3 (2015-08-03)  #{uuid}
     """
 
     tasks = [
@@ -487,10 +487,10 @@ class TestViewportsSpecificSorting(IntegrationTest):
 
     vimoutput = """
     === Work tasks | project:Work or project:Home $T ===
-    * [ ] home task 1 (2015-08-01 00:00)  #{uuid}
-    * [ ] home task 2 (2015-08-02 00:00)  #{uuid}
-    * [ ] work task 1 (2015-08-01 00:00)  #{uuid}
-    * [ ] work task 2 (2015-08-02 00:00)  #{uuid}
+    * [ ] home task 1 (2015-08-01)  #{uuid}
+    * [ ] home task 2 (2015-08-02)  #{uuid}
+    * [ ] work task 1 (2015-08-01)  #{uuid}
+    * [ ] work task 2 (2015-08-02)  #{uuid}
     """
 
     tasks = [
@@ -518,16 +518,16 @@ class TestViewportsSpecificSortingCombined(TestViewportsSpecificSorting):
 
     vimoutput = """
     === Work tasks | project:Work or project:Home $T ===
-    * [ ] home task 1 (2015-08-01 00:00)  #{uuid}
-    * [ ] home task 2 (2015-08-02 00:00)  #{uuid}
-    * [ ] work task 1 (2015-08-01 00:00)  #{uuid}
-    * [ ] work task 2 (2015-08-02 00:00)  #{uuid}
+    * [ ] home task 1 (2015-08-01)  #{uuid}
+    * [ ] home task 2 (2015-08-02)  #{uuid}
+    * [ ] work task 1 (2015-08-01)  #{uuid}
+    * [ ] work task 2 (2015-08-02)  #{uuid}
 
     === Work tasks | project:Work or project:Home ===
-    * [ ] home task 1 (2015-08-01 00:00)  #{uuid}
-    * [ ] work task 1 (2015-08-01 00:00)  #{uuid}
-    * [ ] home task 2 (2015-08-02 00:00)  #{uuid}
-    * [ ] work task 2 (2015-08-02 00:00)  #{uuid}
+    * [ ] home task 1 (2015-08-01)  #{uuid}
+    * [ ] work task 1 (2015-08-01)  #{uuid}
+    * [ ] home task 2 (2015-08-02)  #{uuid}
+    * [ ] work task 2 (2015-08-02)  #{uuid}
     """
 
 

--- a/tests/test_vwtask.py
+++ b/tests/test_vwtask.py
@@ -324,7 +324,7 @@ class TestSimpleTaskWithDueDateCreation(IntegrationTest):
     """
 
     vimoutput = """
-    * [ ] This is a test task (2015-03-03 00:00)  #{uuid}
+    * [ ] This is a test task (2015-03-03)  #{uuid}
     """
 
     def execute(self):


### PR DESCRIPTION
Quite often the due date does not have a time set (i.e. 00:00). So only printing the date and omitting the time saves a lot of space in the taskwiki lists.