### PR TITLE
Fix <CR> mapping (use nnoremap instead of nmap)

### DIFF
--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -88,7 +88,7 @@ if !hasmapto('<Plug>VimwikiFollowLink')
   nmap <Plug>NoVimwikiFollowLink <Plug>VimwikiFollowLink
 endif
 
-execute "nmap <silent><buffer> <CR> :" . g:taskwiki_py . "Mappings.task_info_or_vimwiki_follow_link()<CR>"
+execute "nnoremap <silent><buffer> <CR> :" . g:taskwiki_py . "Mappings.task_info_or_vimwiki_follow_link()<CR>"
 
 " Leader-related mappings. Mostly <Leader>t + <first letter of the action>
 nmap <silent><buffer> <Leader>ta :TaskWikiAnnotate<CR>


### PR DESCRIPTION
This fixes non-working <CR> key to follow vimwiki links / display task infos