### PR TITLE
Fixed bug that cursor reset when after TaskWikiBufferSave/Load

### DIFF
--- a/taskwiki/decorators.py
+++ b/taskwiki/decorators.py
@@ -1,0 +1,12 @@
+import vim  # pylint: disable=F0401
+
+def hold_vim_cursor(original_function):
+    """
+    Decorator that wrap around to save cursor position and restore it
+    """
+
+    def wrapped_function(*args, **kwargs):
+        vim.command('let save_pos = getpos(".")')
+        original_function(*args, **kwargs)
+        vim.command('call setpos(".", save_pos)')
+    return wrapped_function

--- a/taskwiki/main.py
+++ b/taskwiki/main.py
@@ -16,6 +16,7 @@ from taskwiki import cache as cache_module
 from taskwiki import sort
 from taskwiki import util
 from taskwiki import viewport
+from taskwiki import decorators
 
 
 cache = cache_module.CacheRegistry()
@@ -25,6 +26,7 @@ cache.load_current()
 class WholeBuffer(object):
     @staticmethod
     @errors.pretty_exception_handler
+    @decorators.hold_vim_cursor
     def update_from_tw():
         """
         Updates all the incomplete tasks in the vimwiki file if the info from TW is different.
@@ -42,6 +44,7 @@ class WholeBuffer(object):
 
     @staticmethod
     @errors.pretty_exception_handler
+    @decorators.hold_vim_cursor
     def update_to_tw():
         """
         Updates all tasks that differ from their TaskWarrior representation.


### PR DESCRIPTION
Hi guys, I'm using this plugin on neovim. I think this should be a bug. Every time when I tried to save with plugin enabled, it reset my cursor to beginning of the line. This PR hack solves the problem by saving the cursor and restore it. 

BTW, I tried testing it but it seems task git repo link is broken. After [fixing](https://github.com/daizeng1984/taskwiki/commit/902ad33f4eeeeaf5d13b8e7b5e66adc3a23a97ce) it, it seems to work on Python3.5. master branch's Python2.7 integ test still cannot work.
