### PR TITLE
Making taskwiki multi markup compatible

### DIFF
--- a/taskwiki/cache.py
+++ b/taskwiki/cache.py
@@ -117,6 +117,7 @@ class TaskCache(object):
         self.line = store.LineStore(self)
         self.warriors = store.WarriorStore(default_rc, default_data, extra_warrior_defs)
         self.buffer_has_authority = True
+        self.syntax = None
 
     @property
     def vimwikitask_dependency_order(self):
@@ -139,6 +140,15 @@ class TaskCache(object):
         self.vwtask.store = dict()
         self.viewport.store = dict()
         self.line.store = dict()
+        self.syntax = None
+
+    def load_syntax(self):
+        # Fetch syntax information from taskwiki config
+        syntax = util.get_var('taskwiki_syntax')
+        if syntax is in ["default", "markdown", "restructuredtext"]:
+            self.syntax = syntax
+        else:
+            self.syntax = "default"
 
     def load_vwtasks(self, buffer_has_authority=True):
         # Set the authority flag, which determines which data (Buffer or TW)

--- a/taskwiki/main.py
+++ b/taskwiki/main.py
@@ -34,6 +34,7 @@ class WholeBuffer(object):
 
         c = cache()
         c.reset()
+        c.load_syntax()
         c.load_tasks()
         c.load_vwtasks(buffer_has_authority=False)
         c.load_viewports()
@@ -52,6 +53,7 @@ class WholeBuffer(object):
 
         c = cache()
         c.reset()
+        c.load_syntax()
         c.load_tasks()
         c.load_vwtasks()
         c.load_viewports()

--- a/taskwiki/regexp.py
+++ b/taskwiki/regexp.py
@@ -19,6 +19,16 @@ TEXT = r'(?P<text>.+?)'
 COMPLETION_MARK = r'(?P<completed>.)'
 PRIORITY = r'(?P<priority>!{1,3})'
 
+DATETIME_FORMAT = "(%Y-%m-%d %H:%M)"
+DATE_FORMAT = "(%Y-%m-%d)"
+
+ANSI_ESCAPE_SEQ = re.compile(
+    '\x1b'     # literal ESC
+    '\['       # literal [
+    '[;\d]*'   # zero or more digits or semicolons
+    '[A-Za-z]' # a letter
+    )
+
 GENERIC_TASK = re.compile(''.join([
     '^',
     EMPTY_SPACE,
@@ -38,39 +48,98 @@ GENERIC_TASK = re.compile(''.join([
     '$'    # Enforce match on the whole line
 ]))
 
-DATETIME_FORMAT = "(%Y-%m-%d %H:%M)"
-DATE_FORMAT = "(%Y-%m-%d)"
+VIEWPORT = {
+    'default':
+    re.compile(
+        '^'                     # Starts at the begging of the line
+        '[=]+'                  # Heading begging
+        '(?P<name>[^=\|\[\{]*)' # Name of the viewport, all before the | sign
+                                # Cannot include '[', '=', '|, and '{'
+        '\|'                    # Colon
+        '(?P<filter>[^=\|]+?)'  # Filter
+        '('                     # Optional defaults
+        '\|'                    # Colon
+        '(?P<defaults>[^=\|]+?)'# Default attrs
+        ')?'
+        '\s*'                   # Any whitespace
+        '(#(?P<source>[A-Z]))?' # Optional source indicator
+        '\s*'                   # Any whitespace
+        '(\$(?P<sort>[A-Z]))?'  # Optional sort indicator
+        '\s*'                   # Any whitespace
+        '[=]+'                  # Header ending
+    ),
+    'markdown':
+    re.compile(
+        '^'                     # Starts at the begging of the line
+        '[#]+'                  # Heading begging
+        '\s'                    # A whitespace
+        '(?P<name>[^#\|\[\{]*)' # Name of the viewport, all before the | sign
+                                # Cannot include '[', '#', '|, and '{'
+        '\|'                    # Colon
+        '(?P<filter>[^\|]+?)'   # Filter
+        '('                     # Optional defaults
+        '\|'                    # Colon
+        '(?P<defaults>[^\|]+?)' # Default attrs
+        ')?'
+        '\s*'                   # Any whitespace
+        '(#(?P<source>[A-Z]))?' # Optional source indicator
+        '\s*'                   # Any whitespace
+        '(\$(?P<sort>[A-Z]))?'  # Optional sort indicator
+        '\s*'                   # Any whitespace
+        '([#]+)?'               # Optional Header ending
+    ),
+    'restructuredtext':
+    re.compile(
+        '^'                         # Starts at the beginning of the first line
+        '[^\s]'                     # No whitespace
+        '(?P<name>[^\|\[\{]*)'      # Name of the viewport, all before the | sign
+                                    # Cannot include '[', '#', '|, and '{'
+        '\|'                        # Colon
+        '(?P<filter>[^\|]+?)'       # Filter
+        '('                         # Optional defaults
+        '\|'                        # Colon
+        '(?P<defaults>[^\|]+?)'     # Default attrs
+        ')?'
+        '\s*'                       # Any whitespace
+        '(#(?P<source>[A-Z]))?'     # Optional source indicator
+        '\s*'                       # Any whitespace
+        '(\$(?P<sort>[A-Z]))?'      # Optional sort indicator
 
-GENERIC_VIEWPORT = re.compile(
-    '^'                          # Starts at the begging of the line
-    '[=]+'                       # Heading begging
-    '(?P<name>[^=\|\[\{]*)'      # Name of the viewport, all before the | sign
-                                 # Cannot include '[', '=', '|, and '{'
-    '\|'                         # Colon
-    '(?P<filter>[^=\|]+?)'       # Filter
-    '('                          # Optional defaults
-      '\|'                       # Colon
-      '(?P<defaults>[^=\|]+?)'   # Default attrs
-    ')?'
-    '\s*'                        # Any whitespace
-    '(#(?P<source>[A-Z]))?'      # Optional source indicator
-    '\s*'                        # Any whitespace
-    '(\$(?P<sort>[A-Z]))?'       # Optional sort indicator
-    '\s*'                        # Any whitespace
-    '[=]+'                       # Header ending
-    )
+        '[^\s]'                     # No whitespace
+        '\r?\n'                     # Portable newlines
+        r"""([-=~:^"#*._+`'])\1+""" # Any non-alphanumeric characters
+        '$'                         # End of line
+    ).
+}
 
-GENERIC_HEADER = re.compile(
-    '^'        # Starts at the beginning of the line
-    '[=]+'     # With a positive number of =
-    '[^=]+'    # Character other than =
-    '[=]+'     # Positive number of =, closing the header
-    '\s*'      # Allow trailing whitespace
-)
+HEADER = {
+    'default':
+    re.compile(
+        '^'        # Starts at the beginning of the line
+        '[=]+'     # With a positive number of =
+        '[^=]+'    # Character other than =
+        '[=]+'     # Positive number of =, closing the header
+        '\s*'      # Allow trailing whitespace
+    ),
+    'markdown':
+    re.compile(
+        '^'        # Starts at the beginning of the line
+        '[#]+'     # With a positive number of #
+        '\s'       # A whitespace
+        '.'        # Any character
+        '([#]+)?'  # Optional Header ending
+        '$'        # End of line
+    ),
+    'restructuredtext':
+    re.compile(
+        '^'                         # Starts at the beginning of the first line
+        '[^\s]+'                    # No whitespace
+        '.*'                        # Any characters
+        '[^\s]+'                    # No whitespace
+        '\r?\n'                     # Portable newlines
+        r"""([-=~:^"#*._+`'])\1+""" # Any non-alphanumeric characters
+        '$'                         # End of line
+    ).
+}
 
-ANSI_ESCAPE_SEQ = re.compile(
-    '\x1b'     # literal ESC
-    '\['       # literal [
-    '[;\d]*'   # zero or more digits or semicolons
-    '[A-Za-z]' # a letter
-    )
+

--- a/taskwiki/viewport.py
+++ b/taskwiki/viewport.py
@@ -195,7 +195,7 @@ class ViewPort(object):
 
     @classmethod
     def parse_line(cls, cache, number):
-        return re.search(regexp.GENERIC_VIEWPORT, cache.buffer[number])
+        return re.search(regexp.VIEWPORT[cache.syntax], cache.buffer[number])
 
     @classmethod
     def from_line(cls, number, cache):

--- a/taskwiki/vwtask.py
+++ b/taskwiki/vwtask.py
@@ -369,5 +369,6 @@ class VimwikiTask(object):
             # If line matches any header that is not a viewport,
             # break the search too
             line = self.cache.buffer[i]
-            if re.match(regexp.GENERIC_HEADER, line):
+            syntax = self.cache.syntax
+            if re.match(regexp.GENERIC_HEADER[syntax], line):
                 break

--- a/tests/base.py
+++ b/tests/base.py
@@ -340,6 +340,7 @@ class MockCache(object):
         self.vwtask = dict()
         self.task = dict()
         self.viewport = dict()
+        self.syntax = None
 
     def reset(self):
         self.warriors.clear()

--- a/tests/test_viewport_parsing.py
+++ b/tests/test_viewport_parsing.py
@@ -5,6 +5,12 @@ import sys
 
 from taskwiki.constants import DEFAULT_SORT_ORDER, DEFAULT_VIEWPORT_VIRTUAL_TAGS
 
+syntax_header = {
+    'default': "== Test | %s ==",
+    'markdown': "## Test | %s",
+    'restructuredtext': "Test | %s\n================",
+}
+syntax_choice = 'default'
 
 class TestParsingVimwikiTask(object):
     def setup(self):
@@ -15,6 +21,9 @@ class TestParsingVimwikiTask(object):
         self.cache.warriors.update({'T': 'extra'})
         self.mockvim.vars.update({'taskwiki_sort_orders': dict(T='extra')})
 
+        # Set syntax
+        self.cache.syntax = syntax_choice
+
         sys.modules['vim'] = self.mockvim
         from taskwiki.viewport import ViewPort
         self.ViewPort = ViewPort
@@ -24,7 +33,7 @@ class TestParsingVimwikiTask(object):
         self.cache.reset()
 
     def test_simple(self):
-        self.cache.buffer[0] = "== Test | project:Home =="
+        self.cache.buffer[0] = syntax_header[syntax_choice] % "project:Home"
         port = self.ViewPort.from_line(0, self.cache)
 
         assert port.taskfilter == list(DEFAULT_VIEWPORT_VIRTUAL_TAGS) + ["(", "project:Home", ")"]
@@ -33,7 +42,7 @@ class TestParsingVimwikiTask(object):
         assert port.tw == 'default'
 
     def test_defaults(self):
-        self.cache.buffer[0] = "== Test | project:Home | +home =="
+        self.cache.buffer[0] = syntax_header[syntax_choice] % "project:Home | +home"
         port = self.ViewPort.from_line(0, self.cache)
 
         assert port.taskfilter == list(DEFAULT_VIEWPORT_VIRTUAL_TAGS) + ["(", "project:Home", ")"]
@@ -43,7 +52,7 @@ class TestParsingVimwikiTask(object):
         assert port.tw == 'default'
 
     def test_different_tw(self):
-        self.cache.buffer[0] = "== Test | project:Home #T =="
+        self.cache.buffer[0] = syntax_header[syntax_choice] % "project:Home #T"
         port = self.ViewPort.from_line(0, self.cache)
 
         assert port.taskfilter == list(DEFAULT_VIEWPORT_VIRTUAL_TAGS) + ["(", "project:Home", ")"]
@@ -52,7 +61,7 @@ class TestParsingVimwikiTask(object):
         assert port.tw == 'extra'
 
     def test_different_sort(self):
-        self.cache.buffer[0] = "== Test | project:Home $T =="
+        self.cache.buffer[0] = syntax_header[syntax_choice] % "project:Home $T"
         port = self.ViewPort.from_line(0, self.cache)
 
         assert port.taskfilter == list(DEFAULT_VIEWPORT_VIRTUAL_TAGS) + ["(", "project:Home", ")"]
@@ -61,7 +70,7 @@ class TestParsingVimwikiTask(object):
         assert port.tw == 'default'
 
     def test_different_sort_with_complex_filter(self):
-        self.cache.buffer[0] = "== Test | project:Home or project:Work $T =="
+        self.cache.buffer[0] = syntax_header[syntax_choice] % "project:Home or project:Work $T"
         port = self.ViewPort.from_line(0, self.cache)
 
         assert port.taskfilter == list(DEFAULT_VIEWPORT_VIRTUAL_TAGS) + ["(", "project:Home", "or", "project:Work", ")"]
@@ -70,7 +79,7 @@ class TestParsingVimwikiTask(object):
         assert port.tw == 'default'
 
     def test_different_sort_tw(self):
-        self.cache.buffer[0] = "== Test | project:Home #T $T =="
+        self.cache.buffer[0] = syntax_header[syntax_choice] % "project:Home #T $T"
         port = self.ViewPort.from_line(0, self.cache)
 
         assert port.taskfilter == list(DEFAULT_VIEWPORT_VIRTUAL_TAGS) + ["(", "project:Home", ")"]
@@ -79,7 +88,7 @@ class TestParsingVimwikiTask(object):
         assert port.tw == 'extra'
 
     def test_defaults_different_tw(self):
-        self.cache.buffer[0] = "== Test | project:Home | +home #T =="
+        self.cache.buffer[0] = syntax_header[syntax_choice] % "project:Home | +home #T"
         port = self.ViewPort.from_line(0, self.cache)
 
         assert port.taskfilter == list(DEFAULT_VIEWPORT_VIRTUAL_TAGS) + ["(", "project:Home", ")"]
@@ -89,7 +98,7 @@ class TestParsingVimwikiTask(object):
         assert port.tw == 'extra'
 
     def test_defaults_different_tw_sort(self):
-        self.cache.buffer[0] = "== Test | project:Home | +home #T $T =="
+        self.cache.buffer[0] = syntax_header[syntax_choice] % "project:Home | +home #T $T"
         port = self.ViewPort.from_line(0, self.cache)
 
         assert port.taskfilter == list(DEFAULT_VIEWPORT_VIRTUAL_TAGS) + ["(", "project:Home", ")"]
@@ -99,7 +108,7 @@ class TestParsingVimwikiTask(object):
         assert port.tw == 'extra'
 
     def test_override_default_virtual_tags_neutral(self):
-        self.cache.buffer[0] = "== Test | project:Home !?DELETED =="
+        self.cache.buffer[0] = syntax_header[syntax_choice] % "project:Home !?DELETED"
         port = self.ViewPort.from_line(0, self.cache)
 
         assert port.taskfilter == ["-PARENT", "(", "project:Home", ")"]
@@ -109,7 +118,7 @@ class TestParsingVimwikiTask(object):
         assert port.tw == 'default'
 
     def test_override_default_virtual_tags_positive(self):
-        self.cache.buffer[0] = "== Test | project:Home !+DELETED =="
+        self.cache.buffer[0] = syntax_header[syntax_choice] % "project:Home !+DELETED"
         port = self.ViewPort.from_line(0, self.cache)
 
         assert port.taskfilter == ["+DELETED", "-PARENT", "(", "project:Home", ")"]
@@ -119,7 +128,7 @@ class TestParsingVimwikiTask(object):
         assert port.tw == 'default'
 
     def test_override_default_virtual_tags_negative(self):
-        self.cache.buffer[0] = "== Test | project:Home !-DELETED =="
+        self.cache.buffer[0] = syntax_header[syntax_choice] % "project:Home !-DELETED"
         port = self.ViewPort.from_line(0, self.cache)
 
         assert port.taskfilter == ["-DELETED", "-PARENT", "(", "project:Home", ")"]
@@ -129,7 +138,7 @@ class TestParsingVimwikiTask(object):
         assert port.tw == 'default'
 
     def test_override_default_virtual_tags_positive_without_forcing(self):
-        self.cache.buffer[0] = "== Test | project:Home +DELETED =="
+        self.cache.buffer[0] = syntax_header[syntax_choice] % "project:Home +DELETED"
         port = self.ViewPort.from_line(0, self.cache)
 
         assert port.taskfilter == ["-PARENT", "(", "project:Home", "+DELETED", ")"]


### PR DESCRIPTION
I am trying to make taskwiki recognise different header syntax of various markups, such as markdown and restructuredtext, and use them as viewports. This is a proposed approach.
I used `CacheRegistry` in `cache.py` as a place to atore the name of the markup in `syntax`. This allows `viewports.py` to query the current markup syntax then select a appropriate regex to match the header of that markup.
I also added a function to `CacheRegistry`, `load_syntax`, to set the markup syntax based on `taskwiki_syntax` to be used for a session. If the `taskwiki_syntax` is not set, then `syntax` will be set to `default` meaning `vimwiki`.
I modified the two test files to test this feature, `base.py` and `test_viewport_parsing.py`. 
In `base.py` I only added `syntax` to `MockCache`.
In `test_viewport_parsing` I created a dictionary of example headers for each markup with string substitution for a viewport.
At the moment this test does not loop over each markup, I only have to select one syntax at the time as I am unsure of how to write the test in the way that each syntax is tested automatically.
So far the test passed for `vimwiki` but not other markups unsurprisingly as I not tested the new regexes rigorously yet.

This is just a proposed concept and can change upon feedback.
