### PR TITLE
Only kill my gvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,8 +246,5 @@ need to install and enable either the `en_US` or `en_GB` locale. For example:
 
     LANG=en_US python -m pytest
 
-Please save any changes in your own gvim instances before starting the tests,
-because they will be terminated after each finished test!
-
 Finally you might want to have a look at [the travis configuration](.travis.yml)
 and consider using a virtual machine or [Xvfb](https://www.x.org/releases/X11R7.6/doc/man/man1/Xvfb.1.xhtml).

--- a/tests/base.py
+++ b/tests/base.py
@@ -10,7 +10,8 @@ import vimrunner
 from tasklib import TaskWarrior, Task
 from time import sleep
 
-server = vimrunner.Server()
+server_name = "TaskWikiTestServer"
+server = vimrunner.Server(name=server_name)
 
 
 class IntegrationTest(object):
@@ -90,7 +91,7 @@ class IntegrationTest(object):
 
     def teardown(self):
         self.client.quit()
-        subprocess.call(['killall', 'gvim'])
+        subprocess.call(['pkill', '-f', 'gvim.*--servername ' + server_name])
         sleep(0.5)  # Killing takes some time
         self.tasks = self.__class__.tasks  # Reset the task list
 


### PR DESCRIPTION
I think I have found a way to prevent the tests from killing all unrelated gvim instances.
It works for me. Let’s hope that travis is happy with it as well.