### PR TITLE
Add support for markdown viewports

### DIFF
--- a/taskwiki/regexp.py
+++ b/taskwiki/regexp.py
@@ -43,7 +43,7 @@ DATE_FORMAT = "(%Y-%m-%d)"
 
 GENERIC_VIEWPORT = re.compile(
     '^'                          # Starts at the begging of the line
-    '[=]+'                       # Heading begging
+    '(([=]+(?=(.*[=]+\s*$)))|([#]+ ))'                       # Heading begging
     '(?P<name>[^=\|\[\{]*)'      # Name of the viewport, all before the | sign
                                  # Cannot include '[', '=', '|, and '{'
     '\|'                         # Colon
@@ -57,7 +57,7 @@ GENERIC_VIEWPORT = re.compile(
     '\s*'                        # Any whitespace
     '(\$(?P<sort>[A-Z]))?'       # Optional sort indicator
     '\s*'                        # Any whitespace
-    '[=]+'                       # Header ending
+    '([=]+|)\s*$'                       # Header ending
     )
 
 GENERIC_HEADER = re.compile(


### PR DESCRIPTION
The regex definition for the viewports was only matching viewports written in the vimwiki syntax. The regex string was modified to also match markdown headings.

This seems to fix #165.