### PR TITLE
fix wrong parent assignment

### DIFF
--- a/taskwiki/vwtask.py
+++ b/taskwiki/vwtask.py
@@ -346,7 +346,9 @@ class VimwikiTask(object):
 
         for i in reversed(range(0, self['line_number'])):
             # Stop looking if there is less indentation
-            if not self.cache.buffer[i].startswith(self['indent']):
+            indentation = len(self.cache.buffer[i]) - len(self.cache.buffer[i].lstrip())
+            indent = self['indent'].replace('\t', '    ')
+            if indentation < len(indent):
                 # The from_line constructor returns None if line doesn't match a task
                 line = self.cache.line[(VimwikiTask, i)]
                 if line:


### PR DESCRIPTION
fixes #167

Previously, the correct parent assignment for tasks only worked if
expandtab was set in vim: if the task currently checked did not start
with the indentation of the new task, the current line was assigned as
the parent. taskwiki uses spaces for indentation, with a fixed length of
4 [0]. If vim is set to use tabs instead of spaces, the checked line
does not start with tabs and is assigned the parent, even if the
actually indentation is the same.

Especially hard-coding the number of spaces for the indentation should
maybe be fixed in the future.

[0]
https://github.com/tbabej/taskwiki/blob/0c964460e6bbfba387b8a2976a3c349aa615e525/taskwiki/sort.py#L170