### PR TITLE
Add support for vim8 terminal.

### DIFF
--- a/taskwiki/main.py
+++ b/taskwiki/main.py
@@ -132,7 +132,7 @@ class SelectedTasks(object):
 
             # Build command template, it is different for neovim and vim
             command = (
-                ('terminal' if util.NEOVIM else '!') +
+                ('terminal' if util.HAS_TERMINAL else '!') +
                 ' task {0} {1} edit'
             )
             vim.command(command.format(location_override, vimwikitask.uuid))

--- a/taskwiki/util.py
+++ b/taskwiki/util.py
@@ -15,6 +15,7 @@ from taskwiki import regexp
 # Detect if command AnsiEsc is available
 ANSI_ESC_AVAILABLE = vim.eval('exists(":AnsiEsc")') == '2'
 NEOVIM = (vim.eval('has("nvim")') == "1")
+HAS_TERMINAL = (NEOVIM or (int(vim.eval("v:version")) >= 800))
 
 def tw_modstring_to_args(line):
     output = []


### PR DESCRIPTION
Taskwiki already supports the Neovim terminal when executing "task
edit", but otherwise assumes that command doesn't exist and falls back
to using "!".

Unfortunately, for users of non-terminal Vim instances, TaskWikiEdit
doesn't work, as "!" doesn't provide a fully functioning terminal,
leading to visual corruption.

Fortunately, vim8 now comes with a compatible implementation of that
command.

Here we extend the 'terminal' detection to check for either Neovim or
Vim8.