### PR TITLE
Extra syntaxes: Add markdown support

### DIFF
--- a/taskwiki/cache.py
+++ b/taskwiki/cache.py
@@ -8,6 +8,7 @@ from taskwiki import regexp
 from taskwiki import store
 from taskwiki import short
 from taskwiki import util
+from taskwiki import errors
 
 
 class BufferProxy(object):
@@ -107,13 +108,23 @@ class TaskCache(object):
         default_rc = util.get_var('taskwiki_taskrc_location') or '~/.taskrc'
         default_data = util.get_var('taskwiki_data_location') or None
         extra_warrior_defs = util.get_var('taskwiki_extra_warriors', {})
+        markup_syntax = util.get_var('taskwiki_markup_syntax') or 'default'
 
         # Handle bytes (vim returnes bytes for Python3)
         if six.PY3:
             default_rc = util.decode_bytes(default_rc)
             default_data = util.decode_bytes(default_data)
             extra_warrior_defs = util.decode_bytes(extra_warrior_defs)
+            markup_syntax = util.decode_bytes(markup_syntax)
 
+        # Validate markup choice and set it
+        if markup_syntax in ["default", "markdown"]:
+            self.markup_syntax = markup_syntax
+        else:
+            msg = "Unknown markup given: {}".format(markup_syntax)
+            raise errors.TaskWikiException(msg)
+
+        # Initialize all the subcomponents
         self.buffer = BufferProxy(buffer_number)
         self.task = store.TaskStore(self)
         self.presets = store.PresetStore(self)

--- a/taskwiki/preset.py
+++ b/taskwiki/preset.py
@@ -41,10 +41,12 @@ class PresetHeader(object):
 
     @classmethod
     def parse_line(cls, cache, number):
-        header = re.search(regexp.GENERIC_HEADER, cache.buffer[number])
+        header = re.search(regexp.HEADER[cache.markup_syntax],
+                           cache.buffer[number])
 
         if header:
-            preset = re.search(regexp.GENERIC_PRESET, cache.buffer[number])
+            preset = re.search(regexp.PRESET[cache.markup_syntax],
+                               cache.buffer[number])
             if preset:
                 return preset
 

--- a/taskwiki/regexp.py
+++ b/taskwiki/regexp.py
@@ -41,47 +41,96 @@ GENERIC_TASK = re.compile(''.join([
 DATETIME_FORMAT = "(%Y-%m-%d %H:%M)"
 DATE_FORMAT = "(%Y-%m-%d)"
 
-GENERIC_VIEWPORT = re.compile(
-    '^'                          # Starts at the beginning of the line
-    '[=]+'                       # Heading beginning
-    '(?P<name>[^=\|\[\{]*)'      # Name of the viewport, all before the | sign
-                                 # Cannot include '[', '=', '|, and '{'
-    '\|'                         # Colon
-    '(?P<filter>[^=\|]+?)'       # Filter
-    '('                          # Optional defaults
-      '\|'                       # Colon
-      '(?P<defaults>[^=\|]+?)'   # Default attrs
-    ')?'
-    '\s*'                        # Any whitespace
-    '(#(?P<source>[A-Z]))?'      # Optional source indicator
-    '\s*'                        # Any whitespace
-    '(\$(?P<sort>[A-Z]))?'       # Optional sort indicator
-    '\s*'                        # Any whitespace
-    '[=]+'                       # Header ending
+VIEWPORT = {
+    'default':
+    re.compile(
+        '^'                     # Starts at the begging of the line
+        '[=]+'                  # Heading begging
+        '(?P<name>[^=\|\[\{]*)'      # Name of the viewport, all before the | sign
+                                    # Cannot include '[', '=', '|, and '{'
+        '\|'                         # Colon
+        '(?P<filter>[^=\|]+?)'       # Filter
+        '('                          # Optional defaults
+        '\|'                         # Colon
+        '(?P<defaults>[^=\|]+?)'     # Default attrs
+        ')?'
+        '\s*'                        # Any whitespace
+        '(#(?P<source>[A-Z]))?'      # Optional source indicator
+        '\s*'                        # Any whitespace
+        '(\$(?P<sort>[A-Z]))?'       # Optional sort indicator
+        '\s*'                        # Any whitespace
+        '[=]+'                  # Header ending
+    ),
+    'markdown':
+    re.compile(
+        '^'                     # Starts at the begging of the line
+        '[#]+'                  # Heading begging
+        '(?P<name>[^#\|\[\{]*)' # Name of the viewport, all before the | sign
+                                # Cannot include '[', '=', '|, and '{'
+        '\|'                    # Colon
+        '(?P<filter>[^#\|]+?)'  # Filter
+        '('                     # Optional defaults
+        '\|'                    # Colon
+        '(?P<defaults>[^#\|]+?)'# Default attrs
+        ')?'
+        '\s*'                   # Any whitespace
+        '(#(?P<source>[A-Z]))?' # Optional source indicator
+        '\s*'                   # Any whitespace
+        '(\$(?P<sort>[A-Z]))?'  # Optional sort indicator
+        '\s*'                   # Any whitespace
+        '$'                     # End of line
     )
+}
 
-GENERIC_PRESET = re.compile(
-    '^'                           # Starts at the beginning of the line
-    '(?P<header_start>[=]+)'      # With a positive number of =
-    '([^=\|\[\{]*)'               # Heading caption, everything up to ||
-                                  # Cannot include '[', '=', '|, and '{'
-    '\|\|'                        # Delimiter
-    '(?P<filter>[^=\|]+?)'        # Filter preset
-    '('                           # Optional defaults
-      '\|\|'                      # Delimiter
-      '(?P<defaults>[^=\|]+?)'    # Default attrs preset
-    ')?'
-    '\s*'                         # Any whitespace
-    '[=]+'                        # Header ending
+HEADER = {
+    'default':
+    re.compile(
+        '^'                      # Starts at the beginning of the line
+        '(?P<header_start>[=]+)' # With a positive number of =
+        '[^=]+'                  # Character other than =
+        '[=]+'                   # Positive number of =, closing the header
+        '\s*'                    # Allow trailing whitespace
+    ),
+    'markdown':
+    re.compile(
+        '^'                      # Starts at the beginning of the line
+        '(?P<header_start>[#]+)' # With a positive number of #
+        '[^#]+'                  # Character other than #
     )
+}
 
-GENERIC_HEADER = re.compile(
-    '^'                      # Starts at the beginning of the line
-    '(?P<header_start>[=]+)' # With a positive number of =
-    '[^=]+'                  # Character other than =
-    '[=]+'                   # Positive number of =, closing the header
-    '\s*'                    # Allow trailing whitespace
-)
+PRESET = {
+    'default':
+    re.compile(
+        '^'                           # Starts at the beginning of the line
+        '(?P<header_start>[=]+)'      # With a positive number of =
+        '([^=\|\[\{]*)'               # Heading caption, everything up to ||
+                                    # Cannot include '[', '=', '|, and '{'
+        '\|\|'                        # Delimiter
+        '(?P<filter>[^=\|]+?)'        # Filter preset
+        '('                           # Optional defaults
+        '\|\|'                      # Delimiter
+        '(?P<defaults>[^=\|]+?)'    # Default attrs preset
+        ')?'
+        '\s*'                         # Any whitespace
+        '[=]+'                        # Header ending
+    ),
+    'markdown':
+    re.compile(
+        '^'                           # Starts at the beginning of the line
+        '(?P<header_start>[#]+)'      # With a positive number of #
+        '([^#\|\[\{]*)'               # Heading caption, everything up to ||
+                                    # Cannot include '[', '#', '|, and '{'
+        '\|\|'                        # Delimiter
+        '(?P<filter>[^#\|]+?)'        # Filter preset
+        '('                           # Optional defaults
+        '\|\|'                      # Delimiter
+        '(?P<defaults>[^#\|]+?)'    # Default attrs preset
+        ')?'
+        '\s*'                   # Any whitespace
+        '$'                     # End of line
+    )
+}
 
 ANSI_ESCAPE_SEQ = re.compile(
     '\x1b'     # literal ESC

--- a/taskwiki/viewport.py
+++ b/taskwiki/viewport.py
@@ -200,7 +200,7 @@ class ViewPort(object):
 
     @classmethod
     def parse_line(cls, cache, number):
-        return re.search(regexp.GENERIC_VIEWPORT, cache.buffer[number])
+        return re.search(regexp.VIEWPORT[cache.markup_syntax], cache.buffer[number])
 
     @classmethod
     def from_line(cls, number, cache):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+import pytest
+import re
+
+markup_headers = {
+    'default': {
+        'HEADER1': "= %s =",
+        'HEADER2': "== %s ==",
+        'HEADER3': "=== %s ===",
+    },
+    'markdown': {
+        'HEADER1': "# %s",
+        'HEADER2': "## %s",
+        'HEADER3': "### %s",
+    }
+}
+
+
+@pytest.fixture(params=markup_headers)
+def test_syntax(request):
+    markup = request.param
+    format_header_dict = markup_headers[markup]
+
+    def header_expand(string):
+        """
+        The function perform string replacement of 'HEADER1(.+)' with a header
+        syntax for a markup containing the string found in '.+'. This function
+        is constructed with a dict of three header levels containing their regex
+        and actual syntax.
+        When a markup is selected and this function is executed, the function
+        will find instance of 'HEADER1' with 1 being any number between 1 and 3
+        inclusive.
+        """
+        for header_level, format_header in format_header_dict.items():
+            regex = header_level + '\((.*?)\)'
+            string = re.sub(regex,
+                            lambda match: format_header % match.group(1),
+                            string)
+        return string
+
+    return (markup, header_expand)

--- a/tests/test_preset.py
+++ b/tests/test_preset.py
@@ -1,16 +1,16 @@
-from tests.base import IntegrationTest
+from tests.base import MultiSyntaxIntegrationTest
 from time import sleep
 
 
-class TestPresetDefaults(IntegrationTest):
+class TestPresetDefaults(MultiSyntaxIntegrationTest):
 
     viminput = """
-    === Work tasks || +work ===
+    HEADER3(Work tasks || +work)
     * [ ] This is a test task
     """
 
     vimoutput = """
-    === Work tasks || +work ===
+    HEADER3(Work tasks || +work)
     * [ ] This is a test task  #{uuid}
     """
 
@@ -24,19 +24,19 @@ class TestPresetDefaults(IntegrationTest):
         assert task['tags'] == set(['work'])
 
 
-class TestPresetHierarchy(IntegrationTest):
+class TestPresetHierarchy(MultiSyntaxIntegrationTest):
 
     viminput = """
-    == Work tasks || +work ==
-    === Hard work tasks || +hard ===
-    === Easy work tasks || +easy ===
+    HEADER2(Work tasks || +work)
+    HEADER3(Hard work tasks || +hard)
+    HEADER3(Easy work tasks || +easy)
     * [ ] This is a test task
     """
 
     vimoutput = """
-    == Work tasks || +work ==
-    === Hard work tasks || +hard ===
-    === Easy work tasks || +easy ===
+    HEADER2(Work tasks || +work)
+    HEADER3(Hard work tasks || +hard)
+    HEADER3(Easy work tasks || +easy)
     * [ ] This is a test task  #{uuid}
     """
 
@@ -50,15 +50,15 @@ class TestPresetHierarchy(IntegrationTest):
         assert task['tags'] == set(['work', 'easy'])
 
 
-class TestPresetSeparateDefaults(IntegrationTest):
+class TestPresetSeparateDefaults(MultiSyntaxIntegrationTest):
 
     viminput = """
-    = Work tasks || +work or +play || +work =
+    HEADER1(Work tasks || +work or +play || +work)
     * [ ] This is a test task
     """
 
     vimoutput = """
-    = Work tasks || +work or +play || +work =
+    HEADER1(Work tasks || +work or +play || +work)
     * [ ] This is a test task  #{uuid}
     """
 
@@ -72,17 +72,17 @@ class TestPresetSeparateDefaults(IntegrationTest):
         assert task['tags'] == set(['work'])
 
 
-class TestPresetNestedDefaults(IntegrationTest):
+class TestPresetNestedDefaults(MultiSyntaxIntegrationTest):
 
     viminput = """
-    == Work tasks || +work ==
-    === Hard work || +hard ===
+    HEADER2(Work tasks || +work)
+    HEADER3(Hard work || +hard)
     * [ ] This is a test task
     """
 
     vimoutput = """
-    == Work tasks || +work ==
-    === Hard work || +hard ===
+    HEADER2(Work tasks || +work)
+    HEADER3(Hard work || +hard)
     * [ ] This is a test task  #{uuid}
     """
 
@@ -96,16 +96,16 @@ class TestPresetNestedDefaults(IntegrationTest):
         assert task['tags'] == set(['work', 'hard'])
 
 
-class TestPresetViewport(IntegrationTest):
+class TestPresetViewport(MultiSyntaxIntegrationTest):
 
     viminput = """
-    == Work tasks || +work ==
-    === Hard work | +hard ===
+    HEADER2(Work tasks || +work)
+    HEADER3(Hard work | +hard)
     """
 
     vimoutput = """
-    == Work tasks || +work ==
-    === Hard work | +hard ===
+    HEADER2(Work tasks || +work)
+    HEADER3(Hard work | +hard)
     * [ ] tag hard work task  #{uuid}
     """
 
@@ -120,17 +120,17 @@ class TestPresetViewport(IntegrationTest):
         self.command("w", regex="written$", lines=1)
 
 
-class TestPresetIgnoreViewport(IntegrationTest):
+class TestPresetIgnoreViewport(MultiSyntaxIntegrationTest):
 
     viminput = """
-    == Work tasks | +work ==
-    === Hard work || +hard ===
+    HEADER2(Work tasks | +work)
+    HEADER3(Hard work || +hard)
     * [ ] This is a test task
     """
 
     vimoutput = """
-    == Work tasks | +work ==
-    === Hard work || +hard ===
+    HEADER2(Work tasks | +work)
+    HEADER3(Hard work || +hard)
     * [ ] This is a test task  #{uuid}
     """
 
@@ -144,42 +144,17 @@ class TestPresetIgnoreViewport(IntegrationTest):
         assert task['tags'] == set(['hard'])
 
 
-class TestPresetViewportDefaultsYesNo(IntegrationTest):
+class TestPresetViewportDefaultsYesNo(MultiSyntaxIntegrationTest):
 
     viminput = """
-    == Work tasks || project:Work or project:Play || project:Work ==
-    === Hard work | +hard ===
+    HEADER2(Work tasks || project:Work or project:Play || project:Work)
+    HEADER3(Hard work | +hard)
     * [ ] This is a test task
     """
 
     vimoutput = """
-    == Work tasks || project:Work or project:Play || project:Work ==
-    === Hard work | +hard ===
-    * [ ] This is a test task  #{uuid}
-    """
-
-    def execute(self):
-        self.command('w', regex='written$', lines=1)
-
-        # Check that only one tasks with this description exists
-        assert len(self.tw.tasks.pending()) == 1
-
-        task = self.tw.tasks.pending()[0]
-        assert task['tags'] == set(['hard'])
-        assert task['project'] == 'Work'
-
-
-class TestPresetViewportDefaultsNoYes(IntegrationTest):
-
-    viminput = """
-    == Work tasks || project:Work ==
-    === Hard work | +hard or +easy | +hard ===
-    * [ ] This is a test task
-    """
-
-    vimoutput = """
-    == Work tasks || project:Work ==
-    === Hard work | +hard or +easy | +hard ===
+    HEADER2(Work tasks || project:Work or project:Play || project:Work)
+    HEADER3(Hard work | +hard)
     * [ ] This is a test task  #{uuid}
     """
 
@@ -194,17 +169,17 @@ class TestPresetViewportDefaultsNoYes(IntegrationTest):
         assert task['project'] == 'Work'
 
 
-class TestPresetViewportDefaultsYesYes(IntegrationTest):
+class TestPresetViewportDefaultsNoYes(MultiSyntaxIntegrationTest):
 
     viminput = """
-    == Work tasks || project:Work or project:Play || project:Work ==
-    === Hard work | +hard or +easy | +hard ===
+    HEADER2(Work tasks || project:Work)
+    HEADER3(Hard work | +hard or +easy | +hard)
     * [ ] This is a test task
     """
 
     vimoutput = """
-    == Work tasks || project:Work or project:Play || project:Work ==
-    === Hard work | +hard or +easy | +hard ===
+    HEADER2(Work tasks || project:Work)
+    HEADER3(Hard work | +hard or +easy | +hard)
     * [ ] This is a test task  #{uuid}
     """
 
@@ -219,17 +194,42 @@ class TestPresetViewportDefaultsYesYes(IntegrationTest):
         assert task['project'] == 'Work'
 
 
-class TestPresetDefaultPreservesTags(IntegrationTest):
+class TestPresetViewportDefaultsYesYes(MultiSyntaxIntegrationTest):
 
     viminput = """
-    == Work tasks || +work ==
-    === Work tasks | +hard ===
+    HEADER2(Work tasks || project:Work or project:Play || project:Work)
+    HEADER3(Hard work | +hard or +easy | +hard)
+    * [ ] This is a test task
+    """
+
+    vimoutput = """
+    HEADER2(Work tasks || project:Work or project:Play || project:Work)
+    HEADER3(Hard work | +hard or +easy | +hard)
+    * [ ] This is a test task  #{uuid}
+    """
+
+    def execute(self):
+        self.command('w', regex='written$', lines=1)
+
+        # Check that only one tasks with this description exists
+        assert len(self.tw.tasks.pending()) == 1
+
+        task = self.tw.tasks.pending()[0]
+        assert task['tags'] == set(['hard'])
+        assert task['project'] == 'Work'
+
+
+class TestPresetDefaultPreservesTags(MultiSyntaxIntegrationTest):
+
+    viminput = """
+    HEADER2(Work tasks || +work)
+    HEADER3(Work tasks | +hard)
     * [ ] hard task
     """
 
     vimoutput = """
-    == Work tasks || +work ==
-    === Work tasks | +hard ===
+    HEADER2(Work tasks || +work)
+    HEADER3(Work tasks | +hard)
     * [ ] hard task  #{uuid}
     """
 

--- a/tests/test_preset_parsing.py
+++ b/tests/test_preset_parsing.py
@@ -16,16 +16,31 @@ class TestParsingPresetHeader(object):
         self.mockvim.reset()
         self.cache.reset()
 
-    def test_simple(self):
-        self.cache.buffer[0] = "== Test || project:Home =="
+    def process_preset_header(self, preset_header, test_syntax):
+        """
+        Expands the example preset_header to a syntax of a markup and pass on to
+        MockVim to be processed.
+        The result of the processed preset_header is collected.
+        """
+        markup, header_expand = test_syntax
+        formatted_preset_header = header_expand(preset_header)
+        print(formatted_preset_header)
+
+        self.cache.markup_syntax = markup
+        self.cache.buffer[0] = formatted_preset_header
         header = self.PresetHeader.from_line(0, self.cache)
+        return header
+
+    def test_simple(self, test_syntax):
+        preset_header = "HEADER2(Test || project:Home)"
+        header = self.process_preset_header(preset_header, test_syntax)
 
         assert header.taskfilter == ["(", "project:Home", ")"]
         assert header.defaults == {'project': 'Home'}
 
-    def test_defaults(self):
-        self.cache.buffer[0] = "== Test || project:Home || +home =="
-        header = self.PresetHeader.from_line(0, self.cache)
+    def test_defaults(self, test_syntax):
+        preset_header = "HEADER2(Test || project:Home || +home)"
+        header = self.process_preset_header(preset_header, test_syntax)
 
         assert header.taskfilter == ["(", "project:Home", ")"]
         assert header.defaults == {'tags': ['home']}

--- a/tests/test_syntax_parsing.py
+++ b/tests/test_syntax_parsing.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+import pytest
+from taskwiki import regexp
+import re
+
+
+class TestParsingSyntax(object):
+    def test_header(self, test_syntax):
+        markup, header_expand = test_syntax
+        header = "HEADER1(Test)"
+        header = header_expand(header)
+
+        print("Markup: %s,\nHeader syntax:\n%s\nRegex pattern:\n%s" % (
+            markup, header, regexp.HEADER[markup].pattern))
+
+        if re.match(regexp.HEADER[markup], header):
+            assert 1
+        else:
+            assert 0
+
+    def test_macro_viewport(self, test_syntax):
+        markup, header_expand = test_syntax
+        viewport = "HEADER1(Test | project:Home | +home #T $T)"
+        viewport = header_expand(viewport)
+
+        print("Viewport syntax:\n%s\nRegex pattern:\n%s" % (
+             viewport, regexp.VIEWPORT[markup].pattern))
+
+        match = re.search(regexp.VIEWPORT[markup], viewport)
+
+        assert match != None
+
+        assert match.group('name').strip() == "Test"
+        assert match.group('filter').strip() == "project:Home"
+        assert match.group('defaults').strip() == "+home"
+        assert match.group('source').strip() == "T"
+        assert match.group('sort').strip() == "T"

--- a/tests/test_viewport.py
+++ b/tests/test_viewport.py
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
-from tests.base import IntegrationTest
+from tests.base import MultiSyntaxIntegrationTest
 from time import sleep
 
 
-class TestViewportsTaskGeneration(IntegrationTest):
+class TestViewportsTaskGeneration(MultiSyntaxIntegrationTest):
 
     viminput = """
-    === Work tasks | +work ===
+    HEADER2(Work tasks | +work)
     """
 
     vimoutput = """
-    === Work tasks | +work ===
+    HEADER2(Work tasks | +work)
     * [ ] tag work task  #{uuid}
     """
 
@@ -23,14 +23,14 @@ class TestViewportsTaskGeneration(IntegrationTest):
         self.command("w", regex="written$", lines=1)
 
 
-class TestViewportsTaskGenerationEmptyFilter(IntegrationTest):
+class TestViewportsTaskGenerationEmptyFilter(MultiSyntaxIntegrationTest):
 
     viminput = """
-    === Work tasks | ===
+    HEADER2(Work tasks |)
     """
 
     vimoutput = """
-    === Work tasks | ===
+    HEADER2(Work tasks |)
     * [ ] some task  #{uuid}
     """
 
@@ -42,15 +42,15 @@ class TestViewportsTaskGenerationEmptyFilter(IntegrationTest):
         self.command("w", regex="written$", lines=1)
 
 
-class TestViewportsTaskRemoval(IntegrationTest):
+class TestViewportsTaskRemoval(MultiSyntaxIntegrationTest):
 
     viminput = """
-    === Work tasks | -work ===
+    HEADER2(Work tasks | -work)
     * [ ] tag work task  #{uuid}
     """
 
     vimoutput = """
-    === Work tasks | -work ===
+    HEADER2(Work tasks | -work)
     """
 
     tasks = [
@@ -61,14 +61,14 @@ class TestViewportsTaskRemoval(IntegrationTest):
         self.command("w", regex="written$", lines=1)
 
 
-class TestViewportsContextTaskGeneration(IntegrationTest):
+class TestViewportsContextTaskGeneration(MultiSyntaxIntegrationTest):
 
     viminput = """
-    === Work tasks | @work ===
+    HEADER2(Work tasks | @work)
     """
 
     vimoutput = """
-    === Work tasks | @work ===
+    HEADER2(Work tasks | @work)
     * [ ] tag work task  #{uuid}
     """
 
@@ -83,14 +83,14 @@ class TestViewportsContextTaskGeneration(IntegrationTest):
         self.command("w", regex="written$", lines=1)
 
 
-class TestViewportsContextComplexFilterTaskGeneration(IntegrationTest):
+class TestViewportsContextComplexFilterTaskGeneration(MultiSyntaxIntegrationTest):
 
     viminput = """
-    === Work tasks | @work or project:Home ===
+    HEADER2(Work tasks | @work or project:Home)
     """
 
     vimoutput = """
-    === Work tasks | @work or project:Home ===
+    HEADER2(Work tasks | @work or project:Home)
     * [ ] home project task  #{uuid}
     * [ ] tag work task  #{uuid}
     """
@@ -107,14 +107,14 @@ class TestViewportsContextComplexFilterTaskGeneration(IntegrationTest):
         self.command("w", regex="written$", lines=1)
 
 
-class TestViewportsTwoContextTaskGeneration(IntegrationTest):
+class TestViewportsTwoContextTaskGeneration(MultiSyntaxIntegrationTest):
 
     viminput = """
-    === Work tasks | @work or @home ===
+    HEADER2(Work tasks | @work or @home)
     """
 
     vimoutput = """
-    === Work tasks | @work or @home ===
+    HEADER2(Work tasks | @work or @home)
     * [ ] home project task  #{uuid}
     * [ ] tag work task  #{uuid}
     """
@@ -132,14 +132,14 @@ class TestViewportsTwoContextTaskGeneration(IntegrationTest):
         self.command("w", regex="written$", lines=1)
 
 
-class TestViewportsContextInvalid(IntegrationTest):
+class TestViewportsContextInvalid(MultiSyntaxIntegrationTest):
 
     viminput = """
-    === Work tasks | @doesnotexist ===
+    HEADER2(Work tasks | @doesnotexist)
     """
 
     vimoutput = """
-    === Work tasks | @doesnotexist ===
+    HEADER2(Work tasks | @doesnotexist)
     """
 
     def execute(self):
@@ -147,15 +147,15 @@ class TestViewportsContextInvalid(IntegrationTest):
                                 "could not be found.", lines=3)
 
 
-class TestViewportDefaultsAssigment(IntegrationTest):
+class TestViewportDefaultsAssigment(MultiSyntaxIntegrationTest):
 
     viminput = """
-    === Work tasks | +work ===
+    HEADER2(Work tasks | +work)
     * [ ] tag work task
     """
 
     vimoutput = """
-    === Work tasks | +work ===
+    HEADER2(Work tasks | +work)
     * [ ] tag work task  #{uuid}
     """
 
@@ -169,15 +169,15 @@ class TestViewportDefaultsAssigment(IntegrationTest):
         assert task['tags'] == set(['work'])
 
 
-class TestViewportDefaultsExplicit(IntegrationTest):
+class TestViewportDefaultsExplicit(MultiSyntaxIntegrationTest):
 
     viminput = """
-    === Work tasks | project:Home +home | project:Chores  ===
+    HEADER2(Work tasks | project:Home +home | project:Chores)
     * [ ] home task
     """
 
     vimoutput = """
-    === Work tasks | project:Home +home | project:Chores  ===
+    HEADER2(Work tasks | project:Home +home | project:Chores)
     """
 
     def execute(self):
@@ -191,15 +191,15 @@ class TestViewportDefaultsExplicit(IntegrationTest):
         assert task['tags'] == set()
 
 
-class TestViewportDefaultsExplicitEmpty(IntegrationTest):
+class TestViewportDefaultsExplicitEmpty(MultiSyntaxIntegrationTest):
 
     viminput = """
-    === Work tasks | project:Home +home | project:  ===
+    HEADER2(Work tasks | project:Home +home | project:)
     * [ ] home task
     """
 
     vimoutput = """
-    === Work tasks | project:Home +home | project:  ===
+    HEADER2(Work tasks | project:Home +home | project:)
     """
 
     def execute(self):
@@ -213,21 +213,21 @@ class TestViewportDefaultsExplicitEmpty(IntegrationTest):
         assert task['tags'] == set()
 
 
-class TestViewportDefaultsTerminatedByHeader(IntegrationTest):
+class TestViewportDefaultsTerminatedByHeader(MultiSyntaxIntegrationTest):
 
     viminput = """
-    === Work tasks | +work ===
+    HEADER2(Work tasks | +work)
     * [ ] tag work task
 
-    === Unrelated work tasks ===
+    HEADER2(Unrelated work tasks)
     * [ ] not tagged work task
     """
 
     vimoutput = """
-    === Work tasks | +work ===
+    HEADER2(Work tasks | +work)
     * [ ] tag work task  #{uuid}
 
-    === Unrelated work tasks ===
+    HEADER2(Unrelated work tasks)
     * [ ] not tagged work task  #{uuid}
     """
 
@@ -246,10 +246,10 @@ class TestViewportDefaultsTerminatedByHeader(IntegrationTest):
         assert task['tags'] == set()
 
 
-class TestViewportInspection(IntegrationTest):
+class TestViewportInspection(MultiSyntaxIntegrationTest):
 
     viminput = """
-    === Work tasks | +work ===
+    HEADER2(Work tasks | +work)
     * [ ] tag work task  #{uuid}
     """
 
@@ -279,13 +279,13 @@ class TestViewportInspection(IntegrationTest):
         assert self.py("print(vim.current.buffer)", regex="<buffer taskwiki.")
 
 
-class TestViewportInspectionWithVisibleTag(IntegrationTest):
+class TestViewportInspectionWithVisibleTag(MultiSyntaxIntegrationTest):
 
     viminput = """
-    === Work tasks | +work -VISIBLE ===
+    HEADER2(Work tasks | +work -VISIBLE)
     * [ ] tag work task  #{uuid}
 
-    === Home tasks | +home ===
+    HEADER2(Home tasks | +home)
     * [ ] tag work task  #{uuid}
     """
 
@@ -317,14 +317,14 @@ class TestViewportInspectionWithVisibleTag(IntegrationTest):
         assert self.py("print(vim.current.buffer)", regex="<buffer taskwiki.")
 
 
-class TestViewportsUnicodeTaskGeneration(IntegrationTest):
+class TestViewportsUnicodeTaskGeneration(MultiSyntaxIntegrationTest):
 
     viminput = """
-    === Work tasks | +work ===
+    HEADER2(Work tasks | +work)
     """
 
     vimoutput = u"""
-    === Work tasks | +work ===
+    HEADER2(Work tasks | +work)
     * [ ] tag work täsk  #{uuid}
     """
 
@@ -336,14 +336,14 @@ class TestViewportsUnicodeTaskGeneration(IntegrationTest):
         self.command("w", regex="written$", lines=1)
 
 
-class TestUnicodeViewportsUnicodeTaskGeneration(IntegrationTest):
+class TestUnicodeViewportsUnicodeTaskGeneration(MultiSyntaxIntegrationTest):
 
     viminput = u"""
-    === Réunion 2017 | project:Réunion2017 ===
+    HEADER2(Réunion 2017 | project:Réunion2017)
     """
 
     vimoutput = u"""
-    === Réunion 2017 | project:Réunion2017 ===
+    HEADER2(Réunion 2017 | project:Réunion2017)
     * [ ] Réunion task 1  #{uuid}
     """
 
@@ -356,15 +356,15 @@ class TestUnicodeViewportsUnicodeTaskGeneration(IntegrationTest):
         assert len(self.tw.tasks.pending()) == 1
 
 
-class TestUnicodeViewportsUnicodeDefaultsAssignment(IntegrationTest):
+class TestUnicodeViewportsUnicodeDefaultsAssignment(MultiSyntaxIntegrationTest):
 
     viminput = u"""
-    === Réunion 2017 | project:Réunion2017 ===
+    HEADER2(Réunion 2017 | project:Réunion2017)
     * [ ] Réunion task 1
     """
 
     vimoutput = u"""
-    === Réunion 2017 | project:Réunion2017 ===
+    HEADER2(Réunion 2017 | project:Réunion2017)
     * [ ] Réunion task 1  #{uuid}
     """
 
@@ -378,14 +378,14 @@ class TestUnicodeViewportsUnicodeDefaultsAssignment(IntegrationTest):
         assert task['project'] == u'Réunion2017'
 
 
-class TestViewportsSortedGeneration(IntegrationTest):
+class TestViewportsSortedGeneration(MultiSyntaxIntegrationTest):
 
     viminput = """
-    === Work tasks | +work ===
+    HEADER2(Work tasks | +work)
     """
 
     vimoutput = """
-    === Work tasks | +work ===
+    HEADER2(Work tasks | +work)
     * [ ] main task 1 (2015-08-07)  #{uuid}
         * [ ] sub task 1a (2015-08-01)  #{uuid}
             * [ ] sub task 1aa  #{uuid}
@@ -426,7 +426,7 @@ class TestViewportsSortedGeneration(IntegrationTest):
 class TestViewportsSortedGenerationReverse(TestViewportsSortedGeneration):
 
     vimoutput = """
-    === Work tasks | +work ===
+    HEADER2(Work tasks | +work)
     * [ ] main task 3 (2015-08-09)  #{uuid}
         * [ ] sub task 3a (2015-08-03)  #{uuid}
         * [ ] sub task 3b  #{uuid}
@@ -446,14 +446,14 @@ class TestViewportsSortedGenerationReverse(TestViewportsSortedGeneration):
         super(TestViewportsSortedGenerationReverse, self).execute()
 
 
-class TestViewportsMultilevelSortedGeneration(IntegrationTest):
+class TestViewportsMultilevelSortedGeneration(MultiSyntaxIntegrationTest):
 
     viminput = """
-    === Work tasks | project:Work or project:Home ===
+    HEADER2(Work tasks | project:Work or project:Home)
     """
 
     vimoutput = """
-    === Work tasks | project:Work or project:Home ===
+    HEADER2(Work tasks | project:Work or project:Home)
     * [ ] home task 1 (2015-08-01)  #{uuid}
     * [ ] home task 2 (2015-08-02)  #{uuid}
     * [ ] home task 3 (2015-08-03)  #{uuid}
@@ -479,14 +479,14 @@ class TestViewportsMultilevelSortedGeneration(IntegrationTest):
         self.command("w", regex="written$", lines=1)
 
 
-class TestViewportsSpecificSorting(IntegrationTest):
+class TestViewportsSpecificSorting(MultiSyntaxIntegrationTest):
 
     viminput = """
-    === Work tasks | project:Work or project:Home $T ===
+    HEADER2(Work tasks | project:Work or project:Home $T)
     """
 
     vimoutput = """
-    === Work tasks | project:Work or project:Home $T ===
+    HEADER2(Work tasks | project:Work or project:Home $T)
     * [ ] home task 1 (2015-08-01)  #{uuid}
     * [ ] home task 2 (2015-08-02)  #{uuid}
     * [ ] work task 1 (2015-08-01)  #{uuid}
@@ -511,19 +511,19 @@ class TestViewportsSpecificSorting(IntegrationTest):
 class TestViewportsSpecificSortingCombined(TestViewportsSpecificSorting):
 
     viminput = """
-    === Work tasks | project:Work or project:Home $T ===
+    HEADER2(Work tasks | project:Work or project:Home $T)
 
-    === Work tasks | project:Work or project:Home ===
+    HEADER2(Work tasks | project:Work or project:Home)
     """
 
     vimoutput = """
-    === Work tasks | project:Work or project:Home $T ===
+    HEADER2(Work tasks | project:Work or project:Home $T)
     * [ ] home task 1 (2015-08-01)  #{uuid}
     * [ ] home task 2 (2015-08-02)  #{uuid}
     * [ ] work task 1 (2015-08-01)  #{uuid}
     * [ ] work task 2 (2015-08-02)  #{uuid}
 
-    === Work tasks | project:Work or project:Home ===
+    HEADER2(Work tasks | project:Work or project:Home)
     * [ ] home task 1 (2015-08-01)  #{uuid}
     * [ ] work task 1 (2015-08-01)  #{uuid}
     * [ ] home task 2 (2015-08-02)  #{uuid}
@@ -531,14 +531,14 @@ class TestViewportsSpecificSortingCombined(TestViewportsSpecificSorting):
     """
 
 
-class TestViewportsSortedInvalidOrder(IntegrationTest):
+class TestViewportsSortedInvalidOrder(MultiSyntaxIntegrationTest):
 
     viminput = """
-    === Work tasks | +work $X ===
+    HEADER2(Work tasks | +work $X)
     """
 
     vimoutput = """
-    === Work tasks | +work $X ===
+    HEADER2(Work tasks | +work $X)
     """
 
     def execute(self):
@@ -547,19 +547,19 @@ class TestViewportsSortedInvalidOrder(IntegrationTest):
             "'Work tasks' is not defined, using default.", lines=2)
 
 
-class TestViewportsVisibleMetaTag(IntegrationTest):
+class TestViewportsVisibleMetaTag(MultiSyntaxIntegrationTest):
 
     viminput = """
-    === Home tasks | project:Home -VISIBLE ===
+    HEADER2(Home tasks | project:Home -VISIBLE)
 
-    === Chores | project:Home.Chores ===
+    HEADER2(Chores | project:Home.Chores)
     """
 
     vimoutput = """
-    === Home tasks | project:Home -VISIBLE ===
+    HEADER2(Home tasks | project:Home -VISIBLE)
     * [ ] home task  #{uuid}
 
-    === Chores | project:Home.Chores ===
+    HEADER2(Chores | project:Home.Chores)
     * [ ] chore task  #{uuid}
     """
 
@@ -574,17 +574,17 @@ class TestViewportsVisibleMetaTag(IntegrationTest):
         self.command("w", regex="written$", lines=1)
 
 
-class TestViewportsPreserveHierarchyUponCompletion(IntegrationTest):
+class TestViewportsPreserveHierarchyUponCompletion(MultiSyntaxIntegrationTest):
 
     viminput = """
-    === Work tasks | +work ===
+    HEADER2(Work tasks | +work)
     * [ ] main task
         * [ ] sub task a
         * [ ] sub task b
     """
 
     vimoutput = """
-    === Work tasks | +work ===
+    HEADER2(Work tasks | +work)
     * [ ] main task  #{uuid}
         * [X] sub task a  #{uuid}
         * [ ] sub task b  #{uuid}
@@ -601,15 +601,15 @@ class TestViewportsPreserveHierarchyUponCompletion(IntegrationTest):
         sleep(0.5)
 
 
-class TestViewportDefaultPreservesTags(IntegrationTest):
+class TestViewportDefaultPreservesTags(MultiSyntaxIntegrationTest):
 
     viminput = """
-    === Work tasks | +work ===
+    HEADER2(Work tasks | +work)
     * [ ] hard task -- +hard
     """
 
     vimoutput = """
-    === Work tasks | +work ===
+    HEADER2(Work tasks | +work)
     * [ ] hard task  #{uuid}
     """
 


### PR DESCRIPTION
This pull-request added markdown markup support to `taskwiki` allowing `taskwiki` to use markdown headers.

The markdown feature can be activated through

    let g:taskwiki_markdown_syntax='markdown'

in `.vimrc`. Otherise, the default vimwiki will be used.

This pull-request include modifications to the test suite to ensure the markdown feature works properly.

At the moment, one or two tests are failing and I am not sure what is wrong with them.

I was hoping to add restructuredtext but the recent addition of preset headers make this tricky.

Based on previous pull-requests (#150 and #152) that tried to add markdown and restructuredtext support.

Fixes #165, though no folding support.

Please give feedback @jerri, @sh78, @thepith, @beuerle 

Edit: Incorrection configuration variable, it should be `g:taskwiki_markup_syntax`.