### PR TITLE
Nvim doesn't imply Python support

### DIFF
--- a/ftplugin/vimwiki/taskwiki.vim
+++ b/ftplugin/vimwiki/taskwiki.vim
@@ -5,10 +5,7 @@ if version < 704
 endif
 
 " Python version detection.
-if has("nvim")
-  let g:taskwiki_py='py3 '
-  let g:taskwiki_pyfile='py3file '
-elseif has("python3") && ! exists("g:taskwiki_use_python2")
+if has("python3") && ! exists("g:taskwiki_use_python2")
   let g:taskwiki_py='py3 '
   let g:taskwiki_pyfile='py3file '
 elseif has("python")


### PR DESCRIPTION
Hi,

`has('python')` and `has('python3')` work the same in Vim and Neovim, so there's no need for that extra check.

That check is even wrong, since Nvim's `:python` and friends won't work either as long as the Python provider isn't installed as well. `has('python')` covers that case.