### PR TITLE
replace deprecated functions

### DIFF
--- a/taskwiki/main.py
+++ b/taskwiki/main.py
@@ -484,7 +484,7 @@ class CallbackSplitMixin(object):
             + util.get_var('taskwiki_py') +
             "callback = {0}('');".format(self.__class__.__name__) +
             "orig_dict, selected_dict = pickle.loads("
-            "base64.decodestring("
+            "base64.decodebytes("
               "six.b(util.get_var('taskwiki_callback', "
                                   "vars_obj=vim.current.buffer.vars)))); "
             "callback.__dict__.update(orig_dict);"

--- a/taskwiki/main.py
+++ b/taskwiki/main.py
@@ -474,7 +474,7 @@ class CallbackSplitMixin(object):
             self.selected.__dict__)
         )
 
-        vim.current.buffer.vars['taskwiki_callback'] = base64.encodestring(
+        vim.current.buffer.vars['taskwiki_callback'] = base64.encodebytes(
             bytes(dump)
         )
 


### PR DESCRIPTION
`base64.encodestring` and `base64.decodestring` are deprecaded since python version 3.1. This PR replaced them with `base64.encodebytes` and `base64.decodebytes`