### PR TITLE
Fix: Modifications on task in multiple viewports

### DIFF
--- a/taskwiki/main.py
+++ b/taskwiki/main.py
@@ -111,9 +111,10 @@ class SelectedTasks(object):
             vimwikitask.update_from_task()
             vimwikitask.update_in_buffer()
             print(u"Task \"{0}\" completed.".format(vimwikitask['description']))
+        WholeBuffer.update_from_tw()
 
-        cache().buffer.push()
-        self.save_action('done')
+        # cache().buffer.push()
+        # self.save_action('done')
 
     @errors.pretty_exception_handler
     def info(self):


### PR DESCRIPTION
I'm not sure why this patch was never applied to master branch. Just trying to move this along with a proper pull request. See #176 

Currently, after modifying a task, it's updating only the task line
where the command is issued (like \td for "done") and if the same task
is being shown in another viewport, that line is not reflected with
modifications.
So, on saving the file, it reverts the modifications.

To handle, updating the entire buffer on task modifications