### PR TITLE
Document taskwiki_markup_syntax

### DIFF
--- a/doc/taskwiki.txt
+++ b/doc/taskwiki.txt
@@ -730,6 +730,13 @@ constructs.
         Example:
         let g:taskwiki_maplocalleader=",t"
 
+*taskwiki_markup_syntax*
+        This variable specifies the markup syntax you want to use in your
+        VimWiki pages. Valid values are "default" and "markdown".
+
+        Example:
+        let g:taskwiki_markup_syntax = "default"
+
 =============================================================================
 9. TROUBLESHOOTING					   *taskwiki-trouble*
 


### PR DESCRIPTION
This documents the taskwiki_markup_syntax setting added in #192.

Ref: https://github.com/tbabej/taskwiki/issues/165#issuecomment-432211801