### PR TITLE
Add tags to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 */__pycache__
 *.pyc
 .coverage
+tags


### PR DESCRIPTION
Ignores helptags file generated by vim in the docs directory as well as
a potential ctags file in the project root.

This is a really minor improvement but the dirty status of my git submodule was nagging at me ;)