### PR TITLE
fix python 3.8 error about "is not" with literal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ env:
   - TASK_VERSION=v2.5.1
 python:
   - "3.6"
+  - "3.7"
+  - "3.8"
 services:
   - docker
 before_install:

--- a/taskwiki/short.py
+++ b/taskwiki/short.py
@@ -38,7 +38,7 @@ class ShortUUID(object):
         # Determine the key of the TW instance
         [key] = [key for key, value in cache.warriors.items()
                  if value == self.tw]
-        prefix = '{0}:'.format(key) if key is not 'default' else ''
+        prefix = '{0}:'.format(key) if key != 'default' else ''
 
         # Return the H:<uuid> or <uuid> value
         return '{0}{1}'.format(prefix, self.value)


### PR DESCRIPTION
After updating python to 3.8 the following error pops up when entering
vimwiki:

```
"~/vimwiki/README.md" 63L, 1510C
Error detected while processing ~/dotfiles/vim/bundle/taskwiki/ftplugin/vimwiki/taskwiki.vim:
line   33:
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "~/dotfiles/vim/bundle/taskwiki/taskwiki/main.py", line 640, in <module>
    WholeBuffer.update_from_tw()
  File "~/dotfiles/vim/bundle/taskwiki/taskwiki/errors.py", line 26, in wrapped_function
    original_function(*args, **kwargs)
  File "~/dotfiles/vim/bundle/taskwiki/taskwiki/decorators.py", line 9, in wrapped_function
    vim.command('let save_pos = getpos(".")')
vim.error: Vim:~/dotfiles/vim/bundle/taskwiki/taskwiki/short.py:41: SyntaxWarning: "is not" with a literal. Did you mean "!="?
```

Changing from `is not` to `!=` solves this issue.