### PR TITLE
attempt to fix the xvfb problem with travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,7 @@ python:
   - "3.8"
 services:
   - docker
-before_install:
-  # Setup virtual framebuffer
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+  - xvfb
 install:
   # Install coverage dependencies
   - pip install coverage coveralls


### PR DESCRIPTION
The approach taken here is the one recommended at https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui.

Tests may still fail for other reasons.