### PR TITLE
Adds expiration date to viewports

### DIFF
--- a/doc/taskwiki.txt
+++ b/doc/taskwiki.txt
@@ -382,8 +382,29 @@ viewport definition:
 
 ~   == Differently ordered home tasks | project:Home $T ==
 
+------------------------
+5.2.4 Expiring viewports
+
+Every time you view or save a vimwiki file that contains taskwiki compatible
+tasks, the task lists will get updated. However, if you want to archive
+a file, this is undesirable as it will be updated every time you open it. In
+such a case, you can add an expiration date to the viewport you want taskwiki
+to ignore, using an exclamation mark and a date:
+
+~   == Will expire on 1st January 2021 | project:my !2021-01-01
+
+After January 1st, 2021, taskwiki will ignore the viewport and will not update
+the task list it contains.
+
+An expiry date can also be set in a preset header. A viewport can override the
+expiry date by specifying a new one:
+
+~   == Whole document is expired.. || !2020-01-01 ==
+~   === ...(expired) | +tag1 ===
+~   === ...except this viewport | +tag2 !2500-01-01 ===
+
 --------------------
-5.2.4 Default filter
+5.2.5 Default filter
 
 By default, every viewport filter is extended with the -DELETED and -PARENT
 virtual tags.
@@ -403,7 +424,7 @@ Examples:
 ~   == Home tasks, excluding deleted | project:Home !-DELETED ==
 
 -----------------------
-5.2.5 Meta virtual tags
+5.2.6 Meta virtual tags
 
 Currently there is one meta virtual tag: -VISIBLE. This tag can be used to
 filter out tasks that are displayed elsewhere in the same taskwiki file.
@@ -415,14 +436,14 @@ Example:
 ~    == Work review tasks | project:Work.Review ==
 
 ----------------
-5.2.6 Inspection
+5.2.7 Inspection
 
 You can inspect a given viewport (see what filter and defaults are being used,
 as well as other pieces of information) by using the |:TaskWikiInspect|
 command (or hitting <CR>) over a viewport definition.
 
 -------------------------------------------
-5.2.7 Usage of existing context definitions
+5.2.8 Usage of existing context definitions
 
 If you use the context feature in Taskwarrior, you can easily reference
 definition of any context using the @[context_name] syntax in the viewport's

--- a/doc/taskwiki.txt
+++ b/doc/taskwiki.txt
@@ -428,8 +428,6 @@ expiry date by specifying a new one:
 ~   === ...(expired) | +tag1 ===
 ~   === ...except this viewport | +tag2 !2500-01-01 ===
 
-The expiry token must be the last in the viewport specification to work.
-
 --------------------
 5.2.6 Default filter
 

--- a/taskwiki/cache.py
+++ b/taskwiki/cache.py
@@ -193,12 +193,18 @@ class TaskCache(object):
             self.viewport[i] = port
 
     def update_vwtasks_in_buffer(self):
-        for task in self.vwtask.values():
-            task.update_in_buffer()
+        for vwtask in self.vwtask.values():
+            port = self.get_viewport_by_task(vwtask.task)
+            if port and port.expired:
+                continue
+            vwtask.update_in_buffer()
 
     def save_tasks(self):
-        for task in self.vimwikitask_dependency_order:
-            task.save_to_tw()
+        for vwtask in self.vimwikitask_dependency_order:
+            port = self.get_viewport_by_task(vwtask.task)
+            if port and port.expired:
+                continue
+            vwtask.save_to_tw()
 
     def load_tasks(self):
         raw_task_info = []
@@ -237,10 +243,15 @@ class TaskCache(object):
 
     def update_vwtasks_from_tasks(self):
         for vwtask in self.vwtask.values():
+            port = self.get_viewport_by_task(vwtask.task)
+            if port and port.expired:
+                continue
             vwtask.update_from_task()
 
     def evaluate_viewports(self):
         for port in self.viewport.values():
+            if port.expired:
+                continue
             port.sync_with_taskwarrior()
 
     def get_viewport_by_task(self, task):

--- a/taskwiki/main.py
+++ b/taskwiki/main.py
@@ -316,6 +316,7 @@ class Meta(object):
             "Displayed tasks: {5}\n"
             "Tasks to be added: {6}\n"
             "Tasks to be deleted: {7}\n"
+            "{8}\n"
         )
 
         if port is not None:
@@ -334,6 +335,9 @@ class Meta(object):
                 len(port.tasks),
                 ', '.join(map(six.text_type, to_add)),
                 ', '.join(map(six.text_type, to_del)),
+                "Expired: " + port.expires
+                if port.expired
+                else 'Expires: ' + (port.expires if port.expires else 'never'),
             )
 
             # Show in the split

--- a/taskwiki/preset.py
+++ b/taskwiki/preset.py
@@ -9,7 +9,7 @@ class PresetHeader(object):
         == Taskwiki tasks || project:taskwiki ==
     """
 
-    def __init__(self, cache, parent, level, filterstring, defaultstring):
+    def __init__(self, cache, parent, level, filterstring, defaultstring, expires=None):
 
         self.level = level
         self.parent = parent
@@ -38,6 +38,8 @@ class PresetHeader(object):
             defaults.update(util.tw_args_to_kwargs(taskfilter))
 
         self.defaults = defaults
+
+        self.expires = expires
 
     @classmethod
     def parse_line(cls, cache, number):
@@ -89,10 +91,11 @@ class PresetHeader(object):
 
 
         defaults = match.group('defaults')
+        expires = match.group('expires')
 
         if six.PY2:
             filterstring = filterstring.decode('utf-8')
             defaults = defaults.decode('utf-8') if defaults is not None else defaults
 
-        self = cls(cache, parent, level, filterstring, defaults)
+        self = cls(cache, parent, level, filterstring, defaults, expires)
         return self

--- a/taskwiki/regexp.py
+++ b/taskwiki/regexp.py
@@ -4,6 +4,7 @@ import re
 UUID_UNNAMED = r'[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
 UUID_UNNAMED_SHORT = r'[0-9a-fA-F]{8}'
 DUE_UNNAMED = r'\(\d{4}-\d\d-\d\d( \d\d:\d\d)?\)'
+EXPIRES_UNNAMED = r'\d{4}-\d\d-\d\d( \d\d:\d\d)?'
 SPACE_UNNAMED = r'\s*'
 NONEMPTY_SPACE_UNNAMED = r'\s+'
 FINAL_SEGMENT_SEPARATOR_UNNAMED = r'(\s+|$)'
@@ -15,6 +16,7 @@ BRACKET_CLOSING = re.escape('] ')
 EMPTY_SPACE = r'(?P<space>\s*)'
 UUID = r'(?P<uuid>{0}|{1})'.format(UUID_UNNAMED, UUID_UNNAMED_SHORT)
 DUE = r'(?P<due>{0})'.format(DUE_UNNAMED)
+EXPIRES = r'(\!(?P<expires>{0}))?'.format(EXPIRES_UNNAMED)
 TEXT = r'(?P<text>.+?)'
 COMPLETION_MARK = r'(?P<completed>.)'
 PRIORITY = r'(?P<priority>!{1,3})'
@@ -38,8 +40,8 @@ GENERIC_TASK = re.compile(''.join([
     '$'    # Enforce match on the whole line
 ]))
 
-DATETIME_FORMAT = "(%Y-%m-%d %H:%M)"
-DATE_FORMAT = "(%Y-%m-%d)"
+DATETIME_FORMAT = "%Y-%m-%d %H:%M"
+DATE_FORMAT = "%Y-%m-%d"
 
 VIEWPORT = {
     'default':
@@ -60,6 +62,8 @@ VIEWPORT = {
         r'\s*'                       # Any whitespace
         r'(\$(?P<sort>[A-Z]))?'      # Optional sort indicator
         r'\s*'                       # Any whitespace
+        + EXPIRES +
+        r'\s*'                       # Any whitespace
         r'[=]+'                      # Header ending
     ),
     'markdown':
@@ -79,6 +83,8 @@ VIEWPORT = {
         r'(#(?P<source>[A-Z]))?'     # Optional source indicator
         r'\s*'                       # Any whitespace
         r'(\$(?P<sort>[A-Z]))?'      # Optional sort indicator
+        r'\s*'                       # Any whitespace
+        + EXPIRES +
         r'\s*'                       # Any whitespace
         r'$'                         # End of line
     )
@@ -115,6 +121,8 @@ PRESET = {
         r'(?P<defaults>[^=\|]+?)'    # Default attrs preset
         r')?'
         r'\s*'                       # Any whitespace
+        + EXPIRES +
+        r'\s*'                       # Any whitespace
         r'[=]+'                      # Header ending
     ),
     'markdown':
@@ -129,6 +137,8 @@ PRESET = {
         r'\|\|'                      # Delimiter
         r'(?P<defaults>[^#\|]+?)'    # Default attrs preset
         r')?'
+        r'\s*'                       # Any whitespace
+        + EXPIRES +
         r'\s*'                       # Any whitespace
         r'$'                         # End of line
     )

--- a/taskwiki/vwtask.py
+++ b/taskwiki/vwtask.py
@@ -137,10 +137,10 @@ class VimwikiTask(object):
                 parsed_due = None
 
                 try:
-                    parsed_due = datetime.strptime(due, regexp.DATETIME_FORMAT)
+                    parsed_due = datetime.strptime(due, "({0})".format(regexp.DATETIME_FORMAT))
                 except ValueError:
                     try:
-                        parsed_due = datetime.strptime(due, regexp.DATE_FORMAT)
+                        parsed_due = datetime.strptime(due, "({0})".format(regexp.DATE_FORMAT))
                     except ValueError:
                         vim.command('echom "Taskwiki: Invalid timestamp '
                                     'on line %s, ignored."'
@@ -323,9 +323,9 @@ class VimwikiTask(object):
 
     def __str__(self):
         due_str = ' ' + (
-                self['due'].strftime(regexp.DATETIME_FORMAT)
+                self['due'].strftime("(" + regexp.DATETIME_FORMAT + ")")
                   if not util.is_midnight(self['due']) else
-                self['due'].strftime(regexp.DATE_FORMAT)
+                self['due'].strftime("(" + regexp.DATE_FORMAT + ")")
                 ) if self['due'] else ''
 
         return ''.join([

--- a/tests/test_preset.py
+++ b/tests/test_preset.py
@@ -16,7 +16,7 @@ class TestPresetDefaults(MultiSyntaxIntegrationTest):
     def execute(self):
         self.command('w', regex='written$', lines=1)
 
-        # Check that only one tasks with this description exists
+        # Check that only one task with this description exists
         assert len(self.tw.tasks.pending()) == 1
 
         task = self.tw.tasks.pending()[0]
@@ -240,3 +240,62 @@ class TestPresetDefaultPreservesTags(MultiSyntaxIntegrationTest):
         assert task['description'] == 'hard task'
         assert task['status'] == 'pending'
         assert task['tags'] == set(['work', 'hard'])
+
+
+class TestPresetExpires(MultiSyntaxIntegrationTest):
+
+    viminput = """
+    HEADER2(Work tasks || !2020-01-01)
+    HEADER3(Work tasks |)
+    * [ ] old task
+    """
+
+    vimoutput = """
+    HEADER2(Work tasks || !2020-01-01)
+    HEADER3(Work tasks |)
+    * [ ] old task
+    """
+
+    tasks = [
+        dict(description="task 1"),
+        dict(description="task 2"),
+        dict(description="task 3"),
+        dict(description="task 4"),
+    ]
+
+    def execute(self):
+        # Generate the tasks
+        self.command("w", regex="written$", lines=1)
+
+
+class TestPresetExpiresWithOverridingViewport(MultiSyntaxIntegrationTest):
+
+    viminput = """
+    HEADER2(Work tasks || !2020-01-01)
+    HEADER3(Work tasks | $T !2500-01-01)
+    * [ ] old task
+    """
+
+    vimoutput = """
+    HEADER2(Work tasks || !2020-01-01)
+    HEADER3(Work tasks | $T !2500-01-01)
+    * [ ] old task  #{uuid}
+    * [ ] task 1  #{uuid}
+    * [ ] task 2  #{uuid}
+    * [ ] task 3  #{uuid}
+    * [ ] task 4  #{uuid}
+    """
+
+    tasks = [
+        dict(description="task 1"),
+        dict(description="task 2"),
+        dict(description="task 3"),
+        dict(description="task 4"),
+    ]
+
+    def execute(self):
+        # Define the ordering T
+        self.command('let g:taskwiki_sort_orders={"T": "description"}')
+
+        # Generate the tasks
+        self.command("w", regex="written$", lines=1)

--- a/tests/test_preset_parsing.py
+++ b/tests/test_preset_parsing.py
@@ -44,3 +44,11 @@ class TestParsingPresetHeader(object):
 
         assert header.taskfilter == ["(", "project:Home", ")"]
         assert header.defaults == {'tags': ['home']}
+
+    def test_expires(self, test_syntax):
+        preset_header = "HEADER2(Test || project:Home !2020-01-01)"
+        header = self.process_preset_header(preset_header, test_syntax)
+
+        assert header.taskfilter == ["(", "project:Home", ")"]
+        assert header.defaults == {"project": "Home"}
+        assert header.expires == "2020-01-01"

--- a/tests/test_viewport.py
+++ b/tests/test_viewport.py
@@ -264,6 +264,7 @@ class TestViewportInspection(MultiSyntaxIntegrationTest):
     Displayed tasks: 1
     Tasks to be added:
     Tasks to be deleted:
+    Expires: never
     """
 
     tasks = [
@@ -300,6 +301,7 @@ class TestViewportInspectionWithVisibleTag(MultiSyntaxIntegrationTest):
     Displayed tasks: 0
     Tasks to be added:
     Tasks to be deleted:
+    Expires: never
     """
 
     tasks = [
@@ -643,3 +645,27 @@ class TestViewportBufferModified(MultiSyntaxIntegrationTest):
         # testfile3 only has header, so refresh on open makes changes
         self.client.edit(testfile3)
         assert self.client.eval('&modified') == '1'
+
+
+class TestExpiredViewport(MultiSyntaxIntegrationTest):
+
+    viminput = """
+    HEADER2(Work tasks | project:Work !2020-01-01)
+    * [ ] Old task
+    """
+
+    vimoutput = """
+    HEADER2(Work tasks | project:Work !2020-01-01)
+    * [ ] Old task
+    """
+
+    tasks = [
+        dict(description="task 1"),
+        dict(description="task 2"),
+        dict(description="task 3"),
+        dict(description="task 4"),
+    ]
+
+    def execute(self):
+        # Generate the tasks
+        self.command("w", regex="written$", lines=1)

--- a/tests/test_viewport_parsing.py
+++ b/tests/test_viewport_parsing.py
@@ -151,3 +151,13 @@ class TestParsingVimwikiTask(object):
         assert port.defaults == {'project':'Home'}
         assert port.sort == DEFAULT_SORT_ORDER
         assert port.tw == 'default'
+
+    def test_expires(self, test_syntax):
+        example_viewport = "HEADER2(Test | project:Home !2020-01-01)"
+        port = self.process_viewport(example_viewport, test_syntax)
+
+        assert port.taskfilter == list(DEFAULT_VIEWPORT_VIRTUAL_TAGS) + ["(", "project:Home", ")"]
+        assert port.name == "Test"
+        #  assert port.expired == True
+        assert port.expires == '2020-01-01'
+        assert port.tw == 'default'


### PR DESCRIPTION
This PR adds the option to expire viewports:

```
# Viewport here | project:my !2020-10-10
```

This will instruct taskwiki to not update the viewport after the expiration date `2020-10-10`.

This is useful for archiving files that contain taskwiki lists. If the user opens them after the expiration date, their content will not be altered.


The syntax is an exclamation mark followed by a date. Using sth like `expires:2020-01-01` may not be desirable, since it can conflict with a UDA named expires.