### PR TITLE
Fix priority field in sort order

### DIFF
--- a/doc/taskwiki.txt
+++ b/doc/taskwiki.txt
@@ -668,8 +668,8 @@ constructs.
 
 *taskwiki_sort_order*
     The default sort order used to sort the tasks within viewports. Defaults
-    to 'status+,end+,due+,pri-,project+'. Expects a comma-separated list of
-    attributes, optionally followed by + or - to denote the increasing or
+    to 'status+,end+,due+,priority-,project+'. Expects a comma-separated list
+    of attributes, optionally followed by + or - to denote the increasing or
     decreasing order, respectively.
 
 *taskwiki_sort_orders*

--- a/taskwiki/constants.py
+++ b/taskwiki/constants.py
@@ -1,2 +1,2 @@
 DEFAULT_VIEWPORT_VIRTUAL_TAGS = ("-DELETED", "-PARENT")
-DEFAULT_SORT_ORDER = "status+,end+,due+,pri-,project+"
+DEFAULT_SORT_ORDER = "status+,end+,due+,priority-,project+"

--- a/tests/test_viewport.py
+++ b/tests/test_viewport.py
@@ -258,7 +258,7 @@ class TestViewportInspection(MultiSyntaxIntegrationTest):
     Name: Work tasks
     Filter used: -DELETED -PARENT ( +work )
     Defaults used: tags:['work']
-    Ordering used: status+,end+,due+,pri-,project+
+    Ordering used: status+,end+,due+,priority-,project+
     Matching taskwarrior tasks: 1
     Displayed tasks: 1
     Tasks to be added:
@@ -294,7 +294,7 @@ class TestViewportInspectionWithVisibleTag(MultiSyntaxIntegrationTest):
     Name: Work tasks
     Filter used: -DELETED -PARENT ( +work )
     Defaults used: tags:['work']
-    Ordering used: status+,end+,due+,pri-,project+
+    Ordering used: status+,end+,due+,priority-,project+
     Matching taskwarrior tasks: 0
     Displayed tasks: 0
     Tasks to be added:


### PR DESCRIPTION
Did not actually change the code. Instead changed the docs referring to
the "priority" field incorrectly as "pri", and changed `constants.py` to
reflect the correct name for it.