### PR TITLE
update urls in taskwiki.txt and fixed figlet, finally!

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Standing on the shoulders of vimwiki and Taskwarrior_
 [![Coverage Status](https://coveralls.io/repos/tools-life/taskwiki/badge.svg?branch=master)](https://coveralls.io/r/tools-life/taskwiki?branch=master)
 [![Code Health](https://landscape.io/github/tbabej/taskwiki/master/landscape.svg?style=flat)](https://landscape.io/github/tbabej/taskwiki/master)
 [![Chat with developers](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/tbabej/taskwiki)
-```                   _____         _   __        ___ _    _
+```
+                   _____         _   __        ___ _    _
         a         |_   _|_ _ ___| | _\ \      / (_) | _(_)         a
    command-line     | |/ _` / __| |/ /\ \ /\ / /| | |/ / |   personal wiki
     todo list       | | (_| \__ \   <  \ V  V / | |   <| |      for vim

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Standing on the shoulders of vimwiki and Taskwarrior_
 [![Coverage Status](https://coveralls.io/repos/tools-life/taskwiki/badge.svg?branch=master)](https://coveralls.io/r/tools-life/taskwiki?branch=master)
 [![Code Health](https://landscape.io/github/tbabej/taskwiki/master/landscape.svg?style=flat)](https://landscape.io/github/tbabej/taskwiki/master)
 [![Chat with developers](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/tbabej/taskwiki)
-                   _____         _   __        ___ _    _                    ~
-        a         |_   _|_ _ ___| | _\ \      / (_) | _(_)         a         ~
-   command-line     | |/ _` / __| |/ /\ \ /\ / /| | |/ / |   personal wiki   ~
-    todo list       | | (_| \__ \   <  \ V  V / | |   <| |      for vim      ~
-     manager        |_|\__,_|___/_|\_\  \_/\_/  |_|_|\_\_|                   ~
-
+```                   _____         _   __        ___ _    _
+        a         |_   _|_ _ ___| | _\ \      / (_) | _(_)         a
+   command-line     | |/ _` / __| |/ /\ \ /\ / /| | |/ / |   personal wiki
+    todo list       | | (_| \__ \   <  \ V  V / | |   <| |      for vim
+     manager        |_|\__,_|___/_|\_\  \_/\_/  |_|_|\_\_|
+```
 ### Installation
 
 #### Make sure you satisfy the requirements

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Standing on the shoulders of vimwiki and Taskwarrior_
 [![Coverage Status](https://coveralls.io/repos/tools-life/taskwiki/badge.svg?branch=master)](https://coveralls.io/r/tools-life/taskwiki?branch=master)
 [![Code Health](https://landscape.io/github/tbabej/taskwiki/master/landscape.svg?style=flat)](https://landscape.io/github/tbabej/taskwiki/master)
 [![Chat with developers](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/tbabej/taskwiki)
-
-         a         |_   _|_ _ ___| | _\ \      / (_) | _(_)         a         ~
-    command-line     | |/ _` / __| |/ /\ \ /\ / /| | |/ / |   personal wiki   ~
-     todo list       | | (_| \__ \   <  \ V  V / | |   <| |      for vim      ~
-                     |_|\__,_|___/_|\_\  \_/\_/  |_|_|\_\_|                   ~
+                   _____         _   __        ___ _    _                    ~
+        a         |_   _|_ _ ___| | _\ \      / (_) | _(_)         a         ~
+   command-line     | |/ _` / __| |/ /\ \ /\ / /| | |/ / |   personal wiki   ~
+    todo list       | | (_| \__ \   <  \ V  V / | |   <| |      for vim      ~
+     manager        |_|\__,_|___/_|\_\  \_/\_/  |_|_|\_\_|                   ~
 
 ### Installation
 

--- a/doc/taskwiki.txt
+++ b/doc/taskwiki.txt
@@ -236,10 +236,10 @@ provides taskwiki file navigation.
 
     git clone https://github.com/majutsushi/tagbar ~/.vim/bundle/
 
-* [vim-taskwarrior](https://github.com/farseer90718/vim-taskwarrior)
+* [vim-taskwarrior](https://github.com/linuxcaffe/taskwarrior.vim)
 enables grid view.
 
-    git clone https://github.com/farseer90718/vim-taskwarrior ~/.vim/bundle/
+    git clone https://github.com/linuxcaffe/taskwarrior.vim ~/.vim/bundle/
 
 =============================================================================
 5. FEATURES IN DETAIL                                     *taskwiki-features*


### PR DESCRIPTION
taskwiki.txt links for taskwarrior.vim now point to http://github.com/linuxcaffe/taskwarrior.vim