### PR TITLE
Fixes tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,6 +13,7 @@ jobs:
           - TASK_VERSION: v2.5.3
           - TASK_VERSION: v2.6.0
           - TASK_VERSION: develop
+            continue-on-error: true
           - VIM_VERSION: v8.0.1850
           - VIM_VERSION: v8.1.2424
           - VIM_VERSION: v8.2.5172

--- a/tests/base.py
+++ b/tests/base.py
@@ -72,7 +72,7 @@ class IntegrationTest(object):
         self.command('let g:taskwiki_taskrc_location="{0}"'.format(self.taskrc_path))
         self.command('let g:vimwiki_list = [{"syntax": "%s", "ext": ".txt","path": "%s"}]' % (self.markup, self.dir))
 
-    def setup(self):
+    def setup_method(self):
         assert not self.client
 
         self.generate_data()
@@ -89,7 +89,7 @@ class IntegrationTest(object):
         self.filepath = os.path.join(self.dir, 'testwiki.txt')
         self.client.edit(self.filepath)
 
-    def teardown(self):
+    def teardown_method(self):
         if not self.client:
             return
 
@@ -213,8 +213,8 @@ class IntegrationTest(object):
                 success = True
                 break
             else:
-                self.teardown()
-                self.setup()
+                self.teardown_method()
+                self.setup_method()
 
         if not success:
             self.check_sanity(soft=False)
@@ -242,9 +242,9 @@ class MultiSyntaxIntegrationTest(IntegrationTest):
 
     markup = None
 
-    def setup(self):
+    def setup_method(self):
         if self.markup:
-            super(MultiSyntaxIntegrationTest, self).setup()
+            super(MultiSyntaxIntegrationTest, self).setup_method()
         else:
             pass
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ def test_syntax(request):
         inclusive.
         """
         for header_level, format_header in format_header_dict.items():
-            regex = header_level + '\((.*?)\)'
+            regex = header_level + r'\((.*?)\)'
             string = re.sub(regex,
                             lambda match: format_header % match.group(1),
                             string)

--- a/tests/test_preset_parsing.py
+++ b/tests/test_preset_parsing.py
@@ -4,7 +4,7 @@ import sys
 
 
 class TestParsingPresetHeader(object):
-    def setup(self):
+    def setup_method(self):
         self.mockvim = MockVim()
         self.cache = MockCache()
 
@@ -12,7 +12,7 @@ class TestParsingPresetHeader(object):
         from taskwiki.preset import PresetHeader
         self.PresetHeader = PresetHeader
 
-    def teardown(self):
+    def teardown_method(self):
         self.mockvim.reset()
         self.cache.reset()
 

--- a/tests/test_selected.py
+++ b/tests/test_selected.py
@@ -1,7 +1,6 @@
 import re
 
 from datetime import datetime
-from tasklib import local_zone
 from tests.base import IntegrationTest
 
 
@@ -578,7 +577,7 @@ class TestStartAction(IntegrationTest):
         for task in self.tasks:
             task.refresh()
 
-        now = local_zone.localize(datetime.now())
+        now = datetime.now().astimezone()
 
         assert self.tasks[0]['status'] == "pending"
         assert self.tasks[1]['status'] == "pending"
@@ -621,7 +620,7 @@ class TestToggleAction(IntegrationTest):
         for task in self.tasks:
             task.refresh()
 
-        now = local_zone.localize(datetime.now())
+        now = datetime.now().astimezone()
 
         assert self.tasks[0]['status'] == "pending"
         assert self.tasks[1]['status'] == "pending"
@@ -659,7 +658,7 @@ class TestStartActionMoved(IntegrationTest):
         for task in self.tasks:
             task.refresh()
 
-        now = local_zone.localize(datetime.now())
+        now = datetime.now().astimezone()
 
         assert self.tasks[0]['status'] == "pending"
         assert self.tasks[1]['status'] == "pending"
@@ -696,7 +695,7 @@ class TestStartActionRange(IntegrationTest):
         for task in self.tasks:
             task.refresh()
 
-        now = local_zone.localize(datetime.now())
+        now = datetime.now().astimezone()
 
         assert self.tasks[0]['status'] == "pending"
         assert self.tasks[1]['status'] == "pending"
@@ -744,7 +743,7 @@ class TestStartActionRedo(IntegrationTest):
         for task in self.tasks:
             task.refresh()
 
-        now = local_zone.localize(datetime.now())
+        now = datetime.now().astimezone()
 
         assert self.tasks[0]['status'] == "pending"
         assert self.tasks[1]['status'] == "pending"
@@ -782,7 +781,7 @@ class TestStopAction(IntegrationTest):
         for task in self.tasks:
             task.refresh()
 
-        now = local_zone.localize(datetime.now())
+        now = datetime.now().astimezone().astimezone()
 
         assert self.tasks[0]['status'] == "pending"
         assert self.tasks[1]['status'] == "pending"
@@ -820,7 +819,7 @@ class TestStopActionMoved(IntegrationTest):
         for task in self.tasks:
             task.refresh()
 
-        now = local_zone.localize(datetime.now())
+        now = datetime.now().astimezone()
 
         assert self.tasks[0]['status'] == "pending"
         assert self.tasks[1]['status'] == "pending"
@@ -899,7 +898,7 @@ class TestStopActionRedo(IntegrationTest):
         for task in self.tasks:
             task.refresh()
 
-        now = local_zone.localize(datetime.now())
+        now = datetime.now().astimezone()
 
         assert self.tasks[0]['status'] == "pending"
         assert self.tasks[1]['status'] == "pending"
@@ -1056,8 +1055,7 @@ class TestModVisibleAction(IntegrationTest):
     ]
 
     def execute(self):
-        today = local_zone.localize(
-            datetime.now().replace(hour=0,minute=0,second=0,microsecond=0))
+        today = datetime.now().replace(hour=0,minute=0,second=0,microsecond=0).astimezone()
 
         self.command(
             "TaskWikiMod due:today",
@@ -1164,7 +1162,7 @@ class TestDoneAction(IntegrationTest):
         for task in self.tasks:
             task.refresh()
 
-        now = local_zone.localize(datetime.now())
+        now = datetime.now().astimezone()
 
         assert self.tasks[0]['status'] == "completed"
         assert self.tasks[1]['status'] == "pending"
@@ -1231,7 +1229,7 @@ class TestDoneActionMoved(IntegrationTest):
         for task in self.tasks:
             task.refresh()
 
-        now = local_zone.localize(datetime.now())
+        now = datetime.now().astimezone()
 
         assert self.tasks[0]['status'] == "pending"
         assert self.tasks[1]['status'] == "completed"
@@ -1268,7 +1266,7 @@ class TestDoneActionRange(IntegrationTest):
         for task in self.tasks:
             task.refresh()
 
-        now = local_zone.localize(datetime.now())
+        now = datetime.now().astimezone()
 
         assert self.tasks[0]['status'] == "completed"
         assert self.tasks[1]['status'] == "completed"
@@ -1315,7 +1313,7 @@ class TestDoneActionRedo(IntegrationTest):
         for task in self.tasks:
             task.refresh()
 
-        now = local_zone.localize(datetime.now())
+        now = datetime.now().astimezone()
 
         assert self.tasks[0]['status'] == "completed"
         assert self.tasks[1]['status'] == "completed"

--- a/tests/test_splits.py
+++ b/tests/test_splits.py
@@ -1,16 +1,15 @@
 import re
 
 from tests.base import IntegrationTest
-from tasklib import local_zone
 from datetime import datetime
 
 
 def current_year():
-    return local_zone.localize(datetime.now()).year
+    return datetime.now().astimezone().year
 
 
 def current_month():
-    current_month_number = local_zone.localize(datetime.now()).month
+    current_month_number = datetime.now().astimezone().month
     months = ["January", "February", "March", "April",
               "May", "June", "July", "August",
               "September", "October", "November", "December"]

--- a/tests/test_viewport_parsing.py
+++ b/tests/test_viewport_parsing.py
@@ -7,7 +7,7 @@ from taskwiki.constants import DEFAULT_SORT_ORDER, DEFAULT_VIEWPORT_VIRTUAL_TAGS
 
 
 class TestParsingVimwikiTask(object):
-    def setup(self):
+    def setup_method(self):
         self.mockvim = MockVim()
         self.cache = MockCache()
 
@@ -19,7 +19,7 @@ class TestParsingVimwikiTask(object):
         from taskwiki.viewport import ViewPort
         self.ViewPort = ViewPort
 
-    def teardown(self):
+    def teardown_method(self):
         self.mockvim.reset()
         self.cache.reset()
 

--- a/tests/test_vwtask.py
+++ b/tests/test_vwtask.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from datetime import datetime
-from tasklib import local_zone
 from tests.base import IntegrationTest, MultipleSourceTest
 
 
@@ -292,7 +291,7 @@ class TestSimpleTaskWithDueDatetimeCreation(IntegrationTest):
         task = self.tw.tasks.pending()[0]
         assert task['description'] == 'This is a test task'
         assert task['status'] == 'pending'
-        assert task['due'] == local_zone.localize(due)
+        assert task['due'] == due.astimezone()
 
 
 class TestSimpleTaskWithFlawedDueDatetimeCreation(IntegrationTest):
@@ -338,7 +337,7 @@ class TestSimpleTaskWithDueDateCreation(IntegrationTest):
         task = self.tw.tasks.pending()[0]
         assert task['description'] == 'This is a test task'
         assert task['status'] == 'pending'
-        assert task['due'] == local_zone.localize(due)
+        assert task['due'] == due.astimezone()
 
 
 class TestSimpleTaskWithDueDatetimeModification(IntegrationTest):
@@ -373,7 +372,7 @@ class TestSimpleTaskWithDueDatetimeModification(IntegrationTest):
         task = self.tw.tasks.pending()[0]
         assert task['description'] == 'This is a test task'
         assert task['status'] == 'pending'
-        assert task['due'] == local_zone.localize(due)
+        assert task['due'] == due.astimezone()
 
 
 class TestSimpleTaskWithPriorityCreation(IntegrationTest):

--- a/tests/test_vwtask_parsing.py
+++ b/tests/test_vwtask_parsing.py
@@ -3,17 +3,15 @@ from datetime import datetime
 from tests.base import MockVim, MockCache
 import sys
 
-from tasklib import local_zone
-
 class TestParsingVimwikiTask(object):
-    def setup(self):
+    def setup_method(self):
         self.mockvim = MockVim()
         self.cache = MockCache()
         sys.modules['vim'] = self.mockvim
         from taskwiki.vwtask import VimwikiTask
         self.VimwikiTask = VimwikiTask
 
-    def teardown(self):
+    def teardown_method(self):
         self.cache.reset()
 
     def test_simple(self):
@@ -41,7 +39,7 @@ class TestParsingVimwikiTask(object):
         vwtask = self.VimwikiTask.from_line(self.cache, 0)
 
         assert vwtask['description'] == u"Random task"
-        assert vwtask['due'] == local_zone.localize(datetime(2015,8,8,15,15))
+        assert vwtask['due'] == datetime(2015,8,8,15,15).astimezone()
         assert vwtask['uuid'] == None
         assert vwtask['priority'] == None
         assert vwtask['indent'] == ''
@@ -51,7 +49,7 @@ class TestParsingVimwikiTask(object):
         vwtask = self.VimwikiTask.from_line(self.cache, 0)
 
         assert vwtask['description'] == u"Random task"
-        assert vwtask['due'] == local_zone.localize(datetime(2015,8,8,0,0))
+        assert vwtask['due'] == datetime(2015,8,8,0,0).astimezone()
         assert vwtask['uuid'] == None
         assert vwtask['priority'] == None
         assert vwtask['indent'] == ''
@@ -87,7 +85,7 @@ class TestParsingVimwikiTask(object):
 
         assert vwtask['description'] == u"Due today"
         assert vwtask['priority'] == 'H'
-        assert vwtask['due'] == local_zone.localize(datetime(2015,8,8))
+        assert vwtask['due'] == datetime(2015,8,8).astimezone()
         assert vwtask['uuid'] == None
 
     def test_added_modstring(self):


### PR DESCRIPTION
This PR fixes the tests by removing the `tasklib.local_zone` dependency and fixes a couple of warnings. Python 2 compatibility was not a concern as it is eol.