### PR TITLE
Add option to disable <CR> remap

### DIFF
--- a/doc/taskwiki.txt
+++ b/doc/taskwiki.txt
@@ -764,6 +764,10 @@ constructs.
 *taskwiki_disable*
     Setting any non-empty value for this variable will disable taskwiki.
 
+*taskwiki_disable_cr_mapping*
+    Setting any non-empty value for this variable will prevent taskwiki
+    from remapping <CR>.
+
 *taskwiki_use_python2*
     Setting this variable to non-empty value (such as "yes") will force
     taskwiki to use python2.

--- a/ftplugin/vimwiki/taskwiki.vim
+++ b/ftplugin/vimwiki/taskwiki.vim
@@ -102,7 +102,9 @@ if !exists('g:taskwiki_suppress_mappings')
     nmap <Plug>NoVimwikiFollowLink <Plug>VimwikiFollowLink
   endif
 
-  execute "nnoremap <silent><buffer> <CR> :" . g:taskwiki_py . "Mappings.task_info_or_vimwiki_follow_link()<CR>"
+  if !exists("g:taskwiki_disable_cr_mapping")
+    execute "nnoremap <silent><buffer> <CR> :" . g:taskwiki_py . "Mappings.task_info_or_vimwiki_follow_link()<CR>"
+  endif
 
   " Leader-related mappings. Mostly <Leader>t + <first letter of the action>
   if exists('g:taskwiki_maplocalleader')


### PR DESCRIPTION
For users not using Vimwiki (or its link navigation features) it might be useful to provide an option to disable the following remap
```viml
execute "nnoremap <silent><buffer> <CR> :" . g:taskwiki_py . "Mappings.task_info_or_vimwiki_follow_link()<CR>"
```