### PR TITLE
Accept lowercase 'x' as task complete mark

### DIFF
--- a/after/syntax/vimwiki.vim
+++ b/after/syntax/vimwiki.vim
@@ -41,7 +41,7 @@ endfor
 " Define active and deleted task regions
 " Will be colored dynamically by Meta().source_tw_colors()
 syntax match TaskWikiTaskActive containedin=TaskWikiTask contained contains=@TaskWikiTaskContains /\s*\*\s\[S\]\s[^#]*/
-syntax match TaskWikiTaskCompleted containedin=TaskWikiTask contained contains=@TaskWikiTaskContains /\s*\*\s\[X\]\s[^#]*/
+syntax match TaskWikiTaskCompleted containedin=TaskWikiTask contained contains=@TaskWikiTaskContains /\s*\*\s\[[Xx]\]\s[^#]*/
 syntax match TaskWikiTaskDeleted containedin=TaskWikiTask contained contains=@TaskWikiTaskContains /\s*\*\s*\[D\]\s[^#]*/
 syntax match TaskWikiTaskRecurring containedin=TaskWikiTask contained contains=@TaskWikiTaskContains /\s*\*\s\[R\]\s[^#]*/
 syntax match TaskWikiTaskWaiting containedin=TaskWikiTask contained contains=@TaskWikiTaskContains /\s*\*\s\[W\]\s[^#]*/

--- a/taskwiki/vwtask.py
+++ b/taskwiki/vwtask.py
@@ -110,7 +110,7 @@ class VimwikiTask(object):
                 len(match.group('priority') or [])) # This is either 0,1,2 or 3
 
             # Also make sure changes in the progress field are reflected
-            if self['completed_mark'] == 'X':
+            if self['completed_mark'] in ['X', 'x']:
                 self.task['status'] = 'completed'
                 self.task['start'] = None
                 self.task['end'] = self.task['end'] or datetime.now()


### PR DESCRIPTION
Some people (like myself) sync their vimwiki across devices and thus use different markdown editors. Some of those editors insert a lowercase 'x' when tapping on the checkbox of a task.

This PR makes taskwiki accept both lowercase and uppercase Xes for task completion.