### PR TITLE
Added VimwikiWeblink1 to TaskWikiTaskContains syntax cluster

### DIFF
--- a/after/syntax/vimwiki.vim
+++ b/after/syntax/vimwiki.vim
@@ -22,6 +22,7 @@ syntax cluster TaskWikiTaskContains
                 \ VimwikiCodeT,
                 \ VimwikiEqInT,
                 \ VimwikiLink,
+                \ VimwikiWeblink1,
                 \ VimwikiNoExistsLink,
                 \ VimwikiNoExistsLinkT,
                 \ VimwikiWikiLink,

--- a/taskwiki/main.py
+++ b/taskwiki/main.py
@@ -299,6 +299,13 @@ class Mappings(object):
             ']]' in line,
             column >= line.find('[['),
             column <= line.find(']]') + 1
+        ]) or all([
+            '[' in line,
+            ']' in line,
+            '(' in line,
+            ')' in line,
+            column >= line.find('['),
+            column <= line.find(')') + 1
         ])
 
         if inside_vimwiki_link:

--- a/taskwiki/main.py
+++ b/taskwiki/main.py
@@ -301,8 +301,7 @@ class Mappings(object):
             column <= line.find(']]') + 1
         ]) or all([
             '[' in line,
-            ']' in line,
-            '(' in line,
+            '](' in line,
             ')' in line,
             column >= line.find('['),
             column <= line.find(')') + 1


### PR DESCRIPTION
Resolves #452

@tbabej

- is there anything else we could/should put into the `syntax cluster TaskWikiTaskContains` that is missing?
- will this break non `.md` taskwikis?